### PR TITLE
Make AABB methods to consume self

### DIFF
--- a/splashsurf_lib/benches/benches/bench_neighborhood.rs
+++ b/splashsurf_lib/benches/benches/bench_neighborhood.rs
@@ -50,8 +50,8 @@ pub fn neighborhood_search_spatial_hashing(c: &mut Criterion) {
         &io::vtk_format::particles_from_vtk(PARTICLE_FILE).unwrap();
     let particle_positions = particle_subset(particle_positions.as_slice());
 
-    let mut domain = AxisAlignedBoundingBox3d::from_points(particle_positions);
-    domain.grow_uniformly(COMPACT_SUPPORT_RADIUS as f32);
+    let domain = AxisAlignedBoundingBox3d::from_points(particle_positions)
+        .grow_uniformly(COMPACT_SUPPORT_RADIUS as f32);
 
     let mut group = c.benchmark_group("neighborhood_search");
     group.sample_size(100);
@@ -79,8 +79,8 @@ pub fn neighborhood_search_spatial_hashing_parallel(c: &mut Criterion) {
         &io::vtk_format::particles_from_vtk(PARTICLE_FILE).unwrap();
     let particle_positions = particle_subset(particle_positions.as_slice());
 
-    let mut domain = AxisAlignedBoundingBox3d::from_points(particle_positions);
-    domain.grow_uniformly(COMPACT_SUPPORT_RADIUS as f32);
+    let domain = AxisAlignedBoundingBox3d::from_points(particle_positions)
+        .grow_uniformly(COMPACT_SUPPORT_RADIUS as f32);
 
     let mut group = c.benchmark_group("neighborhood_search");
     group.sample_size(100);

--- a/splashsurf_lib/src/density_map.rs
+++ b/splashsurf_lib/src/density_map.rs
@@ -605,11 +605,10 @@ impl<I: Index, R: Real> SparseDensityMapGenerator<I, R> {
         //
         // This also implies that this density map should always represent a closed surfaces.
         // If particles were closer to the AABB boundary than this margin, there could be holes in the resulting level-set.
-        let allowed_domain = {
-            let mut aabb = grid.aabb().clone();
-            aabb.grow_uniformly(kernel_evaluation_radius.neg());
-            aabb
-        };
+        let allowed_domain = grid
+            .aabb()
+            .clone()
+            .grow_uniformly(-kernel_evaluation_radius);
 
         if allowed_domain.is_degenerate() || !allowed_domain.is_consistent() {
             warn!(

--- a/splashsurf_lib/src/lib.rs
+++ b/splashsurf_lib/src/lib.rs
@@ -383,14 +383,13 @@ pub fn grid_for_reconstruction<I: Index, R: Real>(
     } else {
         profile!("compute minimum enclosing aabb");
 
-        let mut domain_aabb = {
-            let mut aabb = if enable_multi_threading {
+        let domain_aabb = {
+            let aabb = if enable_multi_threading {
                 AxisAlignedBoundingBox3d::par_from_points(particle_positions)
             } else {
                 AxisAlignedBoundingBox3d::from_points(particle_positions)
             };
-            aabb.grow_uniformly(particle_radius);
-            aabb
+            aabb.grow_uniformly(particle_radius)
         };
 
         info!(
@@ -404,9 +403,7 @@ pub fn grid_for_reconstruction<I: Index, R: Real>(
             cube_size,
         )
         .kernel_evaluation_radius;
-        domain_aabb.grow_uniformly(kernel_margin);
-
-        domain_aabb
+        domain_aabb.grow_uniformly(kernel_margin)
     };
 
     Ok(UniformGrid::from_aabb(&domain_aabb, cube_size)?)

--- a/splashsurf_lib/tests/integration_tests/test_neighborhood_search.rs
+++ b/splashsurf_lib/tests/integration_tests/test_neighborhood_search.rs
@@ -101,8 +101,8 @@ fn test_neighborhood_search_spatial_hashing_simple() {
 
     for (particles, mut solution) in generate_simple_test_cases(search_radius) {
         let mut nl = Vec::new();
-        let mut domain = AxisAlignedBoundingBox3d::from_points(particles.as_slice());
-        domain.grow_uniformly(search_radius);
+        let domain = AxisAlignedBoundingBox3d::from_points(particles.as_slice())
+            .grow_uniformly(search_radius);
         neighborhood_search_spatial_hashing::<i32, f32>(
             &domain,
             particles.as_slice(),
@@ -134,8 +134,8 @@ mod tests_from_files {
         let file = "../data/free_particles_125_particles.vtk";
         let particles = io::vtk_format::particles_from_vtk::<f32, _>(file).unwrap();
 
-        let mut domain = AxisAlignedBoundingBox3d::par_from_points(particles.as_slice());
-        domain.scale_uniformly(1.5);
+        let domain =
+            AxisAlignedBoundingBox3d::par_from_points(particles.as_slice()).scale_uniformly(1.5);
 
         let mut nl_naive = Vec::new();
         let mut nl_hashed = Vec::new();
@@ -171,8 +171,8 @@ mod tests_from_files {
         let file = "../data/free_particles_1000_particles.vtk";
         let particles = io::vtk_format::particles_from_vtk::<f32, _>(file).unwrap();
 
-        let mut domain = AxisAlignedBoundingBox3d::par_from_points(particles.as_slice());
-        domain.scale_uniformly(1.5);
+        let domain =
+            AxisAlignedBoundingBox3d::par_from_points(particles.as_slice()).scale_uniformly(1.5);
 
         let mut nl_naive = Vec::new();
         let mut nl_hashed = Vec::new();
@@ -208,8 +208,8 @@ mod tests_from_files {
         let file = "../data/cube_2366_particles.vtk";
         let particles = io::vtk_format::particles_from_vtk::<f32, _>(file).unwrap();
 
-        let mut domain = AxisAlignedBoundingBox3d::par_from_points(particles.as_slice());
-        domain.scale_uniformly(1.5);
+        let domain =
+            AxisAlignedBoundingBox3d::par_from_points(particles.as_slice()).scale_uniformly(1.5);
 
         let mut nl_naive = Vec::new();
         let mut nl_hashed = Vec::new();


### PR DESCRIPTION
Now almost all methods of aabb take a mutable reference of self.  If this methods consume self and return a new aabb, construction chaining is enabled and make the code tidy and expressive. Since aabb struct is small, this modification influences very little about memory occupation.   