### PR TITLE
Optimizations for grid-based dense subdomains

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,7 +173,7 @@ checksum = "fdde5c9cd29ebd706ce1b35600920a33550e402fc998a2e53ad3b42c3c47a192"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -305,7 +305,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -435,9 +435,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "5.4.0"
+version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
+checksum = "6943ae99c34386c84a470c499d3414f66502a41340aa895406e0d2e4a207b91d"
 dependencies = [
  "cfg-if",
  "hashbrown",
@@ -559,9 +559,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.12.3"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 
 [[package]]
 name = "heapless"
@@ -646,12 +646,12 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24fddda5af7e54bf7da53067d6e802dbcc381d0a8eef629df528e3ebf68755cb"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi",
- "rustix 0.38.3",
+ "rustix 0.38.4",
  "windows-sys 0.48.0",
 ]
 
@@ -817,9 +817,9 @@ dependencies = [
 
 [[package]]
 name = "nalgebra"
-version = "0.32.2"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d68d47bba83f9e2006d117a9a33af1524e655516b8919caac694427a6fb1e511"
+checksum = "307ed9b18cc2423f29e83f84fd23a8e73628727990181f18641a8b5dc2ab1caa"
 dependencies = [
  "approx",
  "bytemuck",
@@ -836,9 +836,9 @@ dependencies = [
 
 [[package]]
 name = "nalgebra-macros"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d232c68884c0c99810a5a4d333ef7e47689cfd0edc85efc9e54e1e6bf5212766"
+checksum = "91761aed67d03ad966ef783ae962ef9bbaca728d2dd7ceb7939ec110fffad998"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1057,9 +1057,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.3.3"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "767eb9f07d4a5ebcb39bbf2d452058a93c011373abf6832e24194a1c3f004794"
+checksum = "d220334a184db82b31b83f5ff093e3315280fb2b6bbc032022b2304a509aab7a"
 
 [[package]]
 name = "ppv-lite86"
@@ -1069,9 +1069,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
+checksum = "78803b62cbf1f46fde80d7c0e803111524b9877184cfe7c3033659490ac7a7da"
 dependencies = [
  "unicode-ident",
 ]
@@ -1185,9 +1185,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89089e897c013b3deb627116ae56a6955a72b8bed395c9526af31c9fe528b484"
+checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
 dependencies = [
  "aho-corasick",
  "memchr 2.5.0",
@@ -1197,9 +1197,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa250384981ea14565685dea16a9ccc4d1c541a13f82b9c168572264d1df8c56"
+checksum = "83d3daa6976cffb758ec878f108ba0e062a45b2d6ca3a2cca965338855476caf"
 dependencies = [
  "aho-corasick",
  "memchr 2.5.0",
@@ -1208,9 +1208,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab07dc67230e4a4718e70fd5c20055a4334b121f1f9db8fe63ef39ce9b8c846"
+checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
 name = "rstar"
@@ -1248,9 +1248,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.3"
+version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac5ffa1efe7548069688cd7028f32591853cd7b5b756d41bcffd2353e4fc75b4"
+checksum = "0a962918ea88d644592894bc6dc55acc6c0956488adcebbfb6e273506b7fd6e5"
 dependencies = [
  "bitflags 2.3.3",
  "errno",
@@ -1308,22 +1308,22 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.166"
+version = "1.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d01b7404f9d441d3ad40e6a636a7782c377d2abdbe4fa2440e2edcc2f4f10db8"
+checksum = "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.166"
+version = "1.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd83d6dde2b6b2d466e14d9d1acce8816dedee94f735eac6395808b3483c6d6"
+checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -1459,9 +1459,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.23"
+version = "2.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59fb7d6d8281a51045d62b8eb3a7d1ce347b76f312af50cd3dc0af39c87c1737"
+checksum = "15e3fc8c0c74267e2df136e5e5fb656a464158aa57624053375eb9c8c6e25ae2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1484,22 +1484,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.41"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c16a64ba9387ef3fdae4f9c1a7f07a0997fce91985c0336f1ddc1822b3b37802"
+checksum = "a35fc5b8971143ca348fa6df4f024d4d55264f3468c71ad1c2f365b0a4d58c42"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.41"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d14928354b01c4d6a4f0e549069adef399a284e7995c7ccca94e8a07a5346c59"
+checksum = "463fe12d7993d3b327787537ce8dd4dfa058de32fc2b195ef3cde03dc4771e8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -1643,7 +1643,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.25",
  "wasm-bindgen-shared",
 ]
 
@@ -1665,7 +1665,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.25",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1688,9 +1688,9 @@ dependencies = [
 
 [[package]]
 name = "wide"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40018623e2dba2602a9790faba8d33f2ebdebf4b86561b83928db735f8784728"
+checksum = "aa469ffa65ef7e0ba0f164183697b89b854253fd31aeb92358b7b6155177d62f"
 dependencies = [
  "bytemuck",
  "safe_arch",

--- a/splashsurf/src/reconstruction.rs
+++ b/splashsurf/src/reconstruction.rs
@@ -243,7 +243,7 @@ impl Switch {
 
 /// Executes the `reconstruct` subcommand
 pub fn reconstruct_subcommand(cmd_args: &ReconstructSubcommandArgs) -> Result<(), anyhow::Error> {
-    profile!("reconstruct CLI");
+    profile!("reconstruct subcommand");
 
     let paths = ReconstructionRunnerPathCollection::try_from(cmd_args)
         .context("Failed parsing input file path(s) from command line")?
@@ -816,7 +816,7 @@ pub(crate) fn reconstruction_pipeline_generic<I: Index, R: Real>(
     io_params: &io::FormatParameters,
     check_mesh: bool,
 ) -> Result<(), anyhow::Error> {
-    profile!("surface reconstruction cli");
+    profile!("surface reconstruction");
 
     // Load particle positions and attributes to interpolate
     let (particle_positions, attributes) = io::read_particle_positions_with_attributes(

--- a/splashsurf_lib/benches/benches/bench_subdomain_grid.rs
+++ b/splashsurf_lib/benches/benches/bench_subdomain_grid.rs
@@ -1,0 +1,117 @@
+use criterion::{criterion_group, Criterion, SamplingMode};
+use nalgebra::Vector3;
+use splashsurf_lib::io::particles_from_file;
+use splashsurf_lib::{reconstruct_surface, Parameters, SurfaceReconstruction};
+use std::time::Duration;
+
+fn parameters_canyon() -> Parameters<f32> {
+    let particle_radius = 0.011;
+    let compact_support_radius = 4.0 * particle_radius;
+    let cube_size = 1.5 * particle_radius;
+
+    let parameters = Parameters {
+        particle_radius,
+        rest_density: 1000.0,
+        compact_support_radius,
+        cube_size,
+        iso_surface_threshold: 0.6,
+        domain_aabb: None,
+        enable_multi_threading: true,
+        subdomain_num_cubes_per_dim: Some(32),
+        spatial_decomposition: None,
+    };
+
+    parameters
+}
+
+pub fn grid_canyon(c: &mut Criterion) {
+    let particle_positions: &Vec<Vector3<f32>> = &particles_from_file("C:\\canyon.xyz").unwrap();
+    let parameters = parameters_canyon();
+
+    let mut group = c.benchmark_group("grid_canyon");
+    group.sample_size(10);
+    group.sampling_mode(SamplingMode::Flat);
+    group.warm_up_time(Duration::from_secs(10));
+    group.measurement_time(Duration::from_secs(120));
+
+    let mut reconstruction = SurfaceReconstruction::default();
+
+    group.bench_function("canyon_c_1_50_nc_32", |b| {
+        b.iter(|| {
+            let mut parameters = parameters.clone();
+            parameters.cube_size = 1.5 * parameters.particle_radius;
+            parameters.subdomain_num_cubes_per_dim = Some(32);
+            reconstruction =
+                reconstruct_surface::<i64, _>(particle_positions.as_slice(), &parameters).unwrap()
+        })
+    });
+
+    group.bench_function("canyon_c_1_00_nc_48", |b| {
+        b.iter(|| {
+            let mut parameters = parameters.clone();
+            parameters.cube_size = 1.0 * parameters.particle_radius;
+            parameters.subdomain_num_cubes_per_dim = Some(48);
+            reconstruction =
+                reconstruct_surface::<i64, _>(particle_positions.as_slice(), &parameters).unwrap()
+        })
+    });
+
+    group.bench_function("canyon_c_0_75_nc_64", |b| {
+        b.iter(|| {
+            let mut parameters = parameters.clone();
+            parameters.cube_size = 0.75 * parameters.particle_radius;
+            parameters.subdomain_num_cubes_per_dim = Some(48);
+            reconstruction =
+                reconstruct_surface::<i64, _>(particle_positions.as_slice(), &parameters).unwrap()
+        })
+    });
+}
+
+pub fn grid_optimal_num_cubes_canyon(c: &mut Criterion) {
+    let particle_positions: &Vec<Vector3<f32>> = &particles_from_file("C:\\canyon.xyz").unwrap();
+    let mut parameters = parameters_canyon();
+
+    let mut with_cube_factor = |cube_factor: f32, num_cubes: &[u32]| {
+        parameters.cube_size = cube_factor * parameters.particle_radius;
+
+        let mut group = c.benchmark_group(format!(
+            "grid_optimal_num_cubes_canyon_c_{}",
+            format!("{:.2}", cube_factor).replace('.', "_")
+        ));
+        group.sample_size(10);
+        group.sampling_mode(SamplingMode::Flat);
+        group.warm_up_time(Duration::from_secs(10));
+        group.measurement_time(Duration::from_secs(120));
+
+        let mut reconstruction = SurfaceReconstruction::default();
+
+        let mut gen_test = |num_cubes: u32| {
+            group.bench_function(format!("subdomain_num_cubes_{}", num_cubes), |b| {
+                b.iter(|| {
+                    let mut parameters = parameters.clone();
+                    parameters.subdomain_num_cubes_per_dim = Some(num_cubes);
+                    reconstruction =
+                        reconstruct_surface::<i64, _>(particle_positions.as_slice(), &parameters)
+                            .unwrap()
+                })
+            });
+        };
+
+        for &n in num_cubes {
+            gen_test(n);
+        }
+
+        group.finish();
+    };
+
+    with_cube_factor(1.5, &[18, 24, 28, 32, 40, 48, 56, 64, 68, 72]); // Ideal: 32
+    with_cube_factor(1.0, &[24, 28, 32, 40, 48, 56, 64, 68, 72]); // Ideal: 48
+    with_cube_factor(0.75, &[32, 40, 48, 56, 64, 68, 72]); // Ideal: 64
+    with_cube_factor(0.5, &[40, 48, 56, 64, 68, 72, 78, 82, 96]); // Ideal: 82
+}
+
+criterion_group!(
+    bench_subdomain_grid,
+    grid_canyon,
+    grid_optimal_num_cubes_canyon
+);

--- a/splashsurf_lib/benches/benches/mod.rs
+++ b/splashsurf_lib/benches/benches/mod.rs
@@ -3,3 +3,4 @@ pub mod bench_full;
 pub mod bench_mesh;
 pub mod bench_neighborhood;
 pub mod bench_octree;
+pub mod bench_subdomain_grid;

--- a/splashsurf_lib/benches/splashsurf_lib_benches.rs
+++ b/splashsurf_lib/benches/splashsurf_lib_benches.rs
@@ -7,11 +7,13 @@ use benches::bench_full::bench_full;
 use benches::bench_mesh::bench_mesh;
 use benches::bench_neighborhood::bench_neighborhood;
 use benches::bench_octree::bench_octree;
+use benches::bench_subdomain_grid::bench_subdomain_grid;
 
 criterion_main!(
     bench_aabb,
     bench_mesh,
     bench_octree,
     bench_full,
-    bench_neighborhood
+    bench_neighborhood,
+    bench_subdomain_grid,
 );

--- a/splashsurf_lib/src/dense_subdomains.rs
+++ b/splashsurf_lib/src/dense_subdomains.rs
@@ -1,5 +1,6 @@
 use anyhow::Context;
 use arrayvec::ArrayVec;
+use itertools::Itertools;
 use log::{info, trace};
 use nalgebra::Vector3;
 use num_integer::Integer;
@@ -17,7 +18,7 @@ use crate::mesh::{HexMesh3d, TriMesh3d};
 use crate::neighborhood_search::{
     neighborhood_search_spatial_hashing, neighborhood_search_spatial_hashing_parallel,
 };
-use crate::uniform_grid::{EdgeIndex, PointIndex, UniformCartesianCubeGrid3d};
+use crate::uniform_grid::{EdgeIndex, UniformCartesianCubeGrid3d};
 use crate::{
     new_map, new_parallel_map, profile, Aabb3d, MapType, Parameters, SurfaceReconstruction,
 };
@@ -606,6 +607,7 @@ pub(crate) struct SurfacePatch<I: Index, R: Real> {
     pub exterior_vertex_edge_indices: Vec<(I, EdgeIndex<I>)>,
 }
 
+// TODO: Reduce code duplication between dense and sparse
 pub(crate) fn reconstruction<I: Index, R: Real>(
     parameters: &ParametersSubdomainGrid<I, R>,
     global_particles: &[Vector3<R>],
@@ -633,6 +635,26 @@ pub(crate) fn reconstruction<I: Index, R: Real>(
         "number of mc cubes per subdomain must be fit into usize"
     );
 
+    let max_particles = subdomains
+        .per_subdomain_particles
+        .iter()
+        .map(|p| p.len())
+        .max()
+        .unwrap_or(0);
+    info!("Largest subdomain has {} particles.", max_particles);
+
+    // Maximum number of particles such that a subdomain will be considered "sparse"
+    let sparse_limit = (to_real!(max_particles) * to_real!(0.02))
+        .ceil()
+        .to_usize()
+        .unwrap()
+        .max(10);
+    info!(
+        "Subdomains with {} or less particles will be considered sparse.",
+        sparse_limit
+    );
+
+    // Returns a unique identifier for any edge index of a subdomain that can be later used for stitching
     let globalize_local_edge = |mc_grid: &UniformCartesianCubeGrid3d<I, R>,
                                 subdomain_grid: &UniformCartesianCubeGrid3d<I, R>,
                                 subdomain_index: I,
@@ -713,13 +735,13 @@ pub(crate) fn reconstruction<I: Index, R: Real>(
         // Cache for the level-set values
         levelset_grid: Vec<R>,
         // Cache for indices
-        index_cache: Vec<PointIndex<I>>,
+        index_cache: Vec<I>,
     }
 
     let workspace_tls = ThreadLocal::<RefCell<SubdomainWorkspace<I, R>>>::new();
 
     let reconstruct_dense = |flat_subdomain_idx: I, subdomain_particle_indices: &Vec<usize>| {
-        profile!("inner subdomain_tasks (dense)", parent = parent);
+        //profile!("inner subdomain_tasks (dense)", parent = parent);
 
         // Obtain thread local workspace and clear it
         let mut workspace = workspace_tls.get_or_default().borrow_mut();
@@ -767,7 +789,7 @@ pub(crate) fn reconstruction<I: Index, R: Real>(
         levelset_grid.resize(mc_total_points.to_usize().unwrap(), R::zero());
 
         {
-            //profile!("density grid loop");
+            profile!("density grid loop");
 
             let extents = mc_grid.points_per_dim();
 
@@ -879,9 +901,278 @@ pub(crate) fn reconstruction<I: Index, R: Real>(
         let mut edge_to_vertex = new_map();
 
         {
-            //profile!("mc triangulation loop");
+            profile!("mc triangulation loop");
 
             for flat_cell_idx in I::range(I::zero(), mc_total_cells).iter() {
+                let cell = mc_grid.try_unflatten_cell_index(flat_cell_idx).unwrap();
+
+                let mut vertices_inside = [true; 8];
+                for local_point_index in 0..8 {
+                    let point = cell.global_point_index_of(local_point_index).unwrap();
+                    let flat_point_idx = mc_grid.flatten_point_index(&point);
+                    let flat_point_idx = flat_point_idx.to_usize().unwrap();
+                    // Get value of density map
+                    let density_value = levelset_grid[flat_point_idx];
+                    // Update inside/outside surface flag
+                    vertices_inside[local_point_index] =
+                        density_value > parameters.surface_threshold;
+                }
+
+                for triangle in marching_cubes_triangulation_iter(&vertices_inside) {
+                    let mut global_triangle = [0; 3];
+                    for (v_idx, local_edge_index) in triangle.iter().copied().enumerate() {
+                        let edge = cell
+                            .global_edge_index_of(local_edge_index as usize)
+                            .unwrap();
+                        let vertex_index = *edge_to_vertex.entry(edge).or_insert_with(|| {
+                            // TODO: Nonlinear interpolation
+
+                            let origin_coords = mc_grid.point_coordinates(&edge.origin());
+                            let target_coords = mc_grid.point_coordinates(&edge.target());
+
+                            let flat_origin_idx = mc_grid
+                                .flatten_point_index(&edge.origin())
+                                .to_usize()
+                                .unwrap();
+                            let flat_target_idx = mc_grid
+                                .flatten_point_index(&edge.target())
+                                .to_usize()
+                                .unwrap();
+
+                            let origin_value = levelset_grid[flat_origin_idx];
+                            let target_value = levelset_grid[flat_target_idx];
+
+                            let alpha = (parameters.surface_threshold - origin_value)
+                                / (target_value - origin_value);
+                            let interpolated_coords =
+                                origin_coords * (R::one() - alpha) + target_coords * alpha;
+                            let vertex_coords = interpolated_coords;
+
+                            vertices.push(vertex_coords);
+                            let vertex_index = vertices.len() - 1;
+
+                            let is_interior_vertex = !mc_grid.is_boundary_edge(&edge);
+                            vertex_inside_count += is_interior_vertex as usize;
+                            vertex_inside_flags.push(is_interior_vertex);
+
+                            if !is_interior_vertex {
+                                exterior_vertex_edge_indices.push(globalize_local_edge(
+                                    &mc_grid,
+                                    &parameters.subdomain_grid,
+                                    flat_subdomain_idx,
+                                    &edge,
+                                ));
+                            }
+
+                            vertex_index
+                        });
+
+                        global_triangle[v_idx] = vertex_index;
+                    }
+
+                    let all_tri_vertices_inside = global_triangle
+                        .iter()
+                        .copied()
+                        .all(|v_idx| vertex_inside_flags[v_idx]);
+
+                    triangles.push(global_triangle);
+                    triangle_inside_count += all_tri_vertices_inside as usize;
+                    triangle_inside_flags.push(all_tri_vertices_inside);
+                }
+            }
+        }
+
+        SurfacePatch {
+            vertices,
+            triangles,
+            vertex_inside_count,
+            triangle_inside_count,
+            vertex_inside_flags,
+            triangle_inside_flags,
+            exterior_vertex_edge_indices,
+        }
+    };
+
+    let reconstruct_sparse = |flat_subdomain_idx: I, subdomain_particle_indices: &Vec<usize>| {
+        //profile!("inner subdomain_tasks (dense)", parent = parent);
+
+        // Obtain thread local workspace and clear it
+        let mut workspace = workspace_tls.get_or_default().borrow_mut();
+
+        let SubdomainWorkspace {
+            subdomain_particles,
+            subdomain_particle_densities,
+            levelset_grid,
+            index_cache,
+        } = &mut *workspace;
+
+        let flat_subdomain_idx: I = flat_subdomain_idx;
+        let subdomain_particle_indices: &[usize] = subdomain_particle_indices.as_slice();
+
+        // Collect all particle positions and densities of this subdomain
+        {
+            //profile!("collect subdomain data");
+            gather_subdomain_data(
+                global_particles,
+                subdomain_particle_indices,
+                subdomain_particles,
+            );
+            gather_subdomain_data(
+                global_particle_densities,
+                subdomain_particle_indices,
+                subdomain_particle_densities,
+            );
+        }
+
+        // Get the cell index and AABB of the subdomain
+        let subdomain_idx = parameters
+            .subdomain_grid
+            .try_unflatten_cell_index(flat_subdomain_idx)
+            .expect("Subdomain cell does not exist");
+        let subdomain_aabb = parameters.subdomain_grid.cell_aabb(&subdomain_idx);
+
+        let mc_grid = UniformCartesianCubeGrid3d::new(
+            subdomain_aabb.min(),
+            &[parameters.subdomain_cubes; 3],
+            parameters.cube_size,
+        )
+        .unwrap();
+
+        levelset_grid.fill(R::zero());
+        levelset_grid.resize(mc_total_points.to_usize().unwrap(), R::zero());
+
+        index_cache.clear();
+
+        {
+            profile!("density grid loop");
+
+            let extents = mc_grid.points_per_dim();
+
+            for (p_i, rho_i) in subdomain_particles
+                .iter()
+                .copied()
+                .zip(subdomain_particle_densities.iter().copied())
+            {
+                // Get grid cell containing particle
+                let particle_cell = mc_grid.enclosing_cell(&p_i);
+
+                // Compute lower and upper bounds of the grid points possibly affected by the particle
+                // We want to loop over the vertices of the enclosing cells plus all points in `cube_radius` distance from the cell
+
+                let lower = [
+                    (particle_cell[0] - cube_radius).max(I::zero()),
+                    (particle_cell[1] - cube_radius).max(I::zero()),
+                    (particle_cell[2] - cube_radius).max(I::zero()),
+                ];
+
+                let upper = [
+                    // We add 2 because
+                    //  - we want to loop over all grid points of the cell (+1 for upper points) + the radius
+                    //  - the upper range limit is exclusive (+1)
+                    (particle_cell[0] + cube_radius + I::two()).min(extents[0]),
+                    (particle_cell[1] + cube_radius + I::two()).min(extents[1]),
+                    (particle_cell[2] + cube_radius + I::two()).min(extents[2]),
+                ];
+
+                // Loop over all grid points around the enclosing cell
+                for i in I::range(lower[0], upper[0]).iter() {
+                    for j in I::range(lower[1], upper[1]).iter() {
+                        for k in I::range(lower[2], upper[2]).iter() {
+                            let point_ijk = [i, j, k];
+                            let local_point = mc_grid
+                                .get_point(point_ijk)
+                                .expect("point has to be part of the subdomain grid");
+                            //let point_coordinates = mc_grid.point_coordinates(&point);
+
+                            let subdomain_ijk = subdomain_idx.index();
+                            let mc_cells_per_subdomain = mc_grid.cells_per_dim();
+
+                            fn local_to_global_point_ijk<I: Index>(
+                                local_point_ijk: [I; 3],
+                                subdomain_ijk: [I; 3],
+                                cells_per_subdomain: [I; 3],
+                            ) -> [GlobalIndex; 3] {
+                                let local_point_ijk = local_point_ijk
+                                    .map(|i| <GlobalIndex as NumCast>::from(i).unwrap());
+                                let subdomain_ijk = subdomain_ijk
+                                    .map(|i| <GlobalIndex as NumCast>::from(i).unwrap());
+                                let cells_per_subdomain = cells_per_subdomain
+                                    .map(|i| <GlobalIndex as NumCast>::from(i).unwrap());
+                                let [i, j, k] = local_point_ijk;
+
+                                [
+                                    subdomain_ijk[0] * cells_per_subdomain[0] + i,
+                                    subdomain_ijk[1] * cells_per_subdomain[1] + j,
+                                    subdomain_ijk[2] * cells_per_subdomain[2] + k,
+                                ]
+                            }
+
+                            // Use global coordinate calculation for consistency with neighboring domains
+                            let global_point_ijk = local_to_global_point_ijk(
+                                point_ijk,
+                                subdomain_ijk.clone(),
+                                mc_cells_per_subdomain.clone(),
+                            );
+                            let global_point = parameters
+                                .global_marching_cubes_grid
+                                .get_point(global_point_ijk)
+                                .expect("point has to be part of the global mc grid");
+                            let point_coordinates = parameters
+                                .global_marching_cubes_grid
+                                .point_coordinates(&global_point);
+
+                            let dx = p_i - point_coordinates;
+                            let dx_norm_sq = dx.norm_squared();
+
+                            if dx_norm_sq < squared_support_with_margin {
+                                let v_i = parameters.particle_rest_mass / rho_i;
+                                let r = dx_norm_sq.sqrt();
+                                let w_ij = kernel.evaluate(r);
+                                //let w_ij = kernel.evaluate(dx_norm_sq);
+
+                                let interpolated_value = v_i * w_ij;
+
+                                let flat_point_idx = mc_grid.flatten_point_index(&local_point);
+                                let flat_point_idx = flat_point_idx.to_usize().unwrap();
+                                levelset_grid[flat_point_idx] += interpolated_value;
+
+                                if levelset_grid[flat_point_idx] > parameters.surface_threshold {
+                                    for c in mc_grid
+                                        .cells_adjacent_to_point(
+                                            &mc_grid.get_point_neighborhood(&local_point),
+                                        )
+                                        .iter()
+                                        .flatten()
+                                    {
+                                        let flat_cell_index = mc_grid.flatten_cell_index(c);
+                                        index_cache.push(flat_cell_index);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        let mut vertices = Vec::new();
+        let mut triangles = Vec::new();
+
+        let mut vertex_inside_count = 0;
+        let mut triangle_inside_count = 0;
+
+        let mut vertex_inside_flags = Vec::new();
+        let mut triangle_inside_flags = Vec::new();
+
+        let mut exterior_vertex_edge_indices = Vec::new();
+
+        let mut edge_to_vertex = new_map();
+
+        {
+            profile!("mc triangulation loop");
+
+            index_cache.sort_unstable();
+            for flat_cell_idx in index_cache.iter().copied().dedup() {
                 let cell = mc_grid.try_unflatten_cell_index(flat_cell_idx).unwrap();
 
                 let mut vertices_inside = [true; 8];
@@ -978,7 +1269,13 @@ pub(crate) fn reconstruction<I: Index, R: Real>(
         .copied()
         .zip(subdomains.per_subdomain_particles.par_iter())
         .map(|(flat_subdomain_idx, subdomain_particle_indices)| {
-            reconstruct_dense(flat_subdomain_idx, subdomain_particle_indices)
+            if subdomain_particle_indices.len() <= sparse_limit {
+                profile!("subdomain reconstruction (sparse)", parent = parent);
+                reconstruct_sparse(flat_subdomain_idx, subdomain_particle_indices)
+            } else {
+                profile!("subdomain reconstruction (dense)", parent = parent);
+                reconstruct_dense(flat_subdomain_idx, subdomain_particle_indices)
+            }
         })
         .collect_into_vec(&mut surface_patches);
 

--- a/splashsurf_lib/src/dense_subdomains.rs
+++ b/splashsurf_lib/src/dense_subdomains.rs
@@ -635,7 +635,6 @@ pub(crate) fn reconstruction<I: Index, R: Real>(
     subdomains: &Subdomains<I>,
 ) -> Vec<SurfacePatch<I, R>> {
     profile!(parent, "reconstruction");
-    info!("Starting reconstruction (level-set evaluation and local triangulation).");
 
     let squared_support = parameters.compact_support_radius * parameters.compact_support_radius;
     // Add 1% so that we don't exclude grid points that are just on the kernel boundary
@@ -673,6 +672,8 @@ pub(crate) fn reconstruction<I: Index, R: Real>(
         "Subdomains with {} or less particles will be considered sparse.",
         sparse_limit
     );
+
+    info!("Starting reconstruction (level-set evaluation and local triangulation).");
 
     // Returns a unique identifier for any edge index of a subdomain that can be later used for stitching
     let globalize_local_edge = |mc_grid: &UniformCartesianCubeGrid3d<I, R>,

--- a/splashsurf_lib/src/density_map.rs
+++ b/splashsurf_lib/src/density_map.rs
@@ -21,6 +21,7 @@
 use crate::aabb::Aabb3d;
 use crate::kernel::DiscreteSquaredDistanceCubicKernel;
 use crate::mesh::{HexMesh3d, MeshAttribute, MeshWithData};
+use crate::neighborhood_search::NeighborhoodList;
 use crate::uniform_grid::{OwningSubdomainGrid, Subdomain, UniformGrid};
 use crate::utils::{ChunkSize, ParallelPolicy};
 use crate::{new_map, profile, HashState, Index, MapType, ParallelMapType, Real};
@@ -31,7 +32,6 @@ use rayon::prelude::*;
 use std::cell::RefCell;
 use thiserror::Error as ThisError;
 use thread_local::ThreadLocal;
-use crate::neighborhood_search::NeighborhoodList;
 
 // TODO: Document formulas for the computation of the values
 // TODO: Document that we actually evaluate the SPH interpolation of the constant function f(x) = 1
@@ -171,7 +171,11 @@ pub fn sequential_compute_particle_densities_filtered<I: Index, R: Real, Nl: Nei
         .filter(|(i, _)| filter[*i])
     {
         let mut particle_i_density = kernel.evaluate(R::zero());
-        for particle_j_position in particle_neighbor_lists.neighbors(i).iter().map(|&j| &particle_positions[j]) {
+        for particle_j_position in particle_neighbor_lists
+            .neighbors(i)
+            .iter()
+            .map(|&j| &particle_positions[j])
+        {
             let r_squared = (particle_j_position - particle_i_position).norm_squared();
             particle_i_density += kernel.evaluate(r_squared);
         }

--- a/splashsurf_lib/src/neighborhood_search.rs
+++ b/splashsurf_lib/src/neighborhood_search.rs
@@ -92,6 +92,8 @@ pub fn neighborhood_search_naive<R: Real>(
 
 /// Allocates enough storage for the given number of particles and clears all existing neighborhood lists
 fn init_neighborhood_list(neighborhood_list: &mut Vec<Vec<usize>>, new_len: usize) {
+    profile!("init_neighborhood_list");
+
     let old_len = neighborhood_list.len();
     // Reset all neighbor lists that won't be truncated
     for particle_list in neighborhood_list.iter_mut().take(old_len.min(new_len)) {
@@ -197,6 +199,267 @@ pub fn neighborhood_search_spatial_hashing<I: Index, R: Real>(
                 }
             }
         }
+    }
+}
+
+pub struct FlatNeighborhoodList {
+    /// Offsets to the start of the neighborhood list of the given particle (very last entry contains total number of neighbor particles)
+    pub neighbor_ptr: Vec<usize>,
+    /// Flat particle neighborhood list storage
+    pub neighbors: Vec<usize>,
+}
+
+impl Default for FlatNeighborhoodList {
+    fn default() -> Self {
+        Self {
+            neighbor_ptr: vec![0],
+            neighbors: vec![],
+        }
+    }
+}
+
+impl FlatNeighborhoodList {
+    /// Returns the total number of particles this list has neighborhood information about
+    pub fn len(&self) -> usize {
+        self.neighbor_ptr.len() - 1
+    }
+
+    pub fn get_neighbors(&self, particle_i: usize) -> Option<&[usize]> {
+        let range = self
+            .neighbor_ptr
+            .get(particle_i)
+            .copied()
+            .zip(self.neighbor_ptr.get(particle_i + 1).copied());
+        range.and_then(|(start, end)| self.neighbors.get(start..end))
+    }
+
+    pub fn get_neighbors_mut(&mut self, particle_i: usize) -> Option<&mut [usize]> {
+        let range = self
+            .neighbor_ptr
+            .get(particle_i)
+            .copied()
+            .zip(self.neighbor_ptr.get(particle_i + 1).copied());
+        range.and_then(|(start, end)| self.neighbors.get_mut(start..end))
+    }
+
+    /// Converts this flat neighbor list to its nested `Vec` representation
+    pub fn to_vec_vec(self) -> Vec<Vec<usize>> {
+        let num_particles = self.len();
+        let mut neighbor_list = vec![Vec::new(); num_particles];
+        neighbor_list
+            .iter_mut()
+            .enumerate()
+            .for_each(|(i, nl)| nl.extend(self.get_neighbors(i).unwrap().iter().copied()));
+        neighbor_list
+    }
+}
+
+/// Trait unifying different particle neighborhood list storage formats
+pub trait NeighborhoodList {
+    /// Returns the total number of particles this list has neighborhood information about
+    fn len(&self) -> usize;
+    /// Returns the neighborhood list of the given particle
+    fn neighbors(&self, particle_i: usize) -> &[usize];
+}
+
+impl NeighborhoodList for FlatNeighborhoodList {
+    fn len(&self) -> usize {
+        self.len()
+    }
+
+    fn neighbors(&self, particle_i: usize) -> &[usize] {
+        self.get_neighbors(particle_i).unwrap()
+    }
+}
+
+impl NeighborhoodList for Vec<Vec<usize>> {
+    fn len(&self) -> usize {
+        self.len()
+    }
+
+    fn neighbors(&self, particle_i: usize) -> &[usize] {
+        &self[particle_i]
+    }
+}
+
+pub fn neighborhood_search_spatial_hashing_flat<I: Index, R: Real>(
+    domain: &Aabb3d<R>,
+    particle_positions: &[Vector3<R>],
+    search_radius: R,
+    neighborhood_list: &mut FlatNeighborhoodList,
+) {
+    profile!("neighborhood_search_spatial_hashing_flat");
+
+    assert!(
+        search_radius > R::zero(),
+        "Search radius for neighborhood search has to be positive!"
+    );
+    assert!(
+        domain.is_consistent(),
+        "Domain for neighborhood search has to be consistent!"
+    );
+    assert!(
+        !domain.is_degenerate(),
+        "Domain for neighborhood search cannot be degenerate!"
+    );
+
+    let search_radius_squared = search_radius * search_radius;
+
+    // Create a new grid for neighborhood search
+    let grid = UniformGrid::from_aabb(&domain, search_radius)
+        .expect("Failed to construct grid for neighborhood search!");
+    // Map for spatially hashed storage of all particles (map from cell -> enclosed particles)
+    let particles_per_cell =
+        sequential_generate_cell_to_particle_map::<I, R>(&grid, particle_positions);
+
+    {
+        neighborhood_list.neighbor_ptr.clear();
+        neighborhood_list
+            .neighbor_ptr
+            .resize(particle_positions.len() + 1, 0);
+        neighborhood_list.neighbors.clear();
+    }
+
+    {
+        profile!("write particle neighbors");
+        let mut counter = 0;
+        for (particle_i, pos_i) in particle_positions.iter().enumerate() {
+            // Store start of current particle neighbor list
+            neighborhood_list.neighbor_ptr[particle_i] = counter;
+
+            // Cell of the current particle
+            let current_cell = grid.get_cell(grid.enclosing_cell(pos_i)).unwrap();
+
+            let mut neighbor_test = |particle_j| {
+                let pos_j: &Vector3<R> = &particle_positions[particle_j];
+                if (pos_j - pos_i).norm_squared() < search_radius_squared {
+                    // A neighbor was found
+                    neighborhood_list.neighbors.push(particle_j);
+                    counter += 1;
+                }
+            };
+
+            // Loop over adjacent cells
+            grid.cells_adjacent_to_cell(&current_cell)
+                .filter_map(|c| {
+                    let flat_cell_index = grid.flatten_cell_index(&c);
+                    particles_per_cell.get(&flat_cell_index)
+                })
+                .flatten()
+                .copied()
+                .for_each(|particle_j| neighbor_test(particle_j));
+
+            // Loop over current cell
+            std::iter::once(current_cell)
+                .filter_map(|c| {
+                    let flat_cell_index = grid.flatten_cell_index(&c);
+                    particles_per_cell.get(&flat_cell_index)
+                })
+                .flatten()
+                .copied()
+                .for_each(|particle_j| {
+                    if particle_i != particle_j {
+                        neighbor_test(particle_j);
+                    }
+                });
+        }
+        // Store end of the last neighbor list
+        *neighborhood_list.neighbor_ptr.last_mut().unwrap() = counter;
+    }
+}
+
+pub fn neighborhood_search_spatial_hashing_flat_filtered<I: Index, R: Real>(
+    domain: &Aabb3d<R>,
+    particle_positions: &[Vector3<R>],
+    search_radius: R,
+    neighborhood_list: &mut FlatNeighborhoodList,
+    filter: &[bool],
+) {
+    profile!("neighborhood_search_spatial_hashing_flat_filtered");
+
+    assert!(
+        search_radius > R::zero(),
+        "Search radius for neighborhood search has to be positive!"
+    );
+    assert!(
+        domain.is_consistent(),
+        "Domain for neighborhood search has to be consistent!"
+    );
+    assert!(
+        !domain.is_degenerate(),
+        "Domain for neighborhood search cannot be degenerate!"
+    );
+
+    let search_radius_squared = search_radius * search_radius;
+
+    // Create a new grid for neighborhood search
+    let grid = UniformGrid::from_aabb(&domain, search_radius)
+        .expect("Failed to construct grid for neighborhood search!");
+    // Map for spatially hashed storage of all particles (map from cell -> enclosed particles)
+    let particles_per_cell =
+        sequential_generate_cell_to_particle_map::<I, R>(&grid, particle_positions);
+
+    {
+        neighborhood_list.neighbor_ptr.clear();
+        neighborhood_list
+            .neighbor_ptr
+            .resize(particle_positions.len() + 1, 0);
+        neighborhood_list.neighbors.clear();
+    }
+
+    {
+        profile!("write particle neighbors");
+        let mut counter = 0;
+        for (particle_i, (pos_i, filter)) in particle_positions
+            .iter()
+            .zip(filter.iter().copied())
+            .enumerate()
+        {
+            // Store start of current particle neighbor list
+            neighborhood_list.neighbor_ptr[particle_i] = counter;
+
+            if !filter {
+                continue;
+            }
+
+            // Cell of the current particle
+            let current_cell = grid.get_cell(grid.enclosing_cell(pos_i)).unwrap();
+
+            let mut neighbor_test = |particle_j| {
+                let pos_j: &Vector3<R> = &particle_positions[particle_j];
+                if (pos_j - pos_i).norm_squared() < search_radius_squared {
+                    // A neighbor was found
+                    neighborhood_list.neighbors.push(particle_j);
+                    counter += 1;
+                }
+            };
+
+            // Loop over adjacent cells
+            grid.cells_adjacent_to_cell(&current_cell)
+                .filter_map(|c| {
+                    let flat_cell_index = grid.flatten_cell_index(&c);
+                    particles_per_cell.get(&flat_cell_index)
+                })
+                .flatten()
+                .copied()
+                .for_each(|particle_j| neighbor_test(particle_j));
+
+            // Loop over current cell
+            std::iter::once(current_cell)
+                .filter_map(|c| {
+                    let flat_cell_index = grid.flatten_cell_index(&c);
+                    particles_per_cell.get(&flat_cell_index)
+                })
+                .flatten()
+                .copied()
+                .for_each(|particle_j| {
+                    if particle_i != particle_j {
+                        neighbor_test(particle_j);
+                    }
+                });
+        }
+        // Store end of the last neighbor list
+        *neighborhood_list.neighbor_ptr.last_mut().unwrap() = counter;
     }
 }
 

--- a/splashsurf_lib/src/reconstruction.rs
+++ b/splashsurf_lib/src/reconstruction.rs
@@ -28,11 +28,14 @@ pub(crate) fn reconstruct_surface_subdomain_grid<'a, I: Index, R: Real>(
             decomposition::<I, R, GhostMarginClassifier<I>>(&parameters, &particle_positions)?;
 
         /*
-        subdomain_stats(&parameters, &particle_positions, &subdomains);
-        info!(
-            "Number of subdomains with only ghost particles: {}",
-            count_no_owned_particles_subdomains(&parameters, &particle_positions, &subdomains)
-        );
+        {
+            use super::dense_subdomains::debug::*;
+            subdomain_stats(&parameters, &particle_positions, &subdomains);
+            info!(
+                "Number of subdomains with only ghost particles: {}",
+                count_no_owned_particles_subdomains(&parameters, &particle_positions, &subdomains)
+            );
+        }
          */
 
         let particle_densities =

--- a/splashsurf_lib/tests/integration_tests/test_neighborhood_search.rs
+++ b/splashsurf_lib/tests/integration_tests/test_neighborhood_search.rs
@@ -122,6 +122,33 @@ fn test_neighborhood_search_spatial_hashing_simple() {
 }
 
 #[test]
+fn test_neighborhood_search_spatial_hashing_flat_simple() {
+    let search_radius: f32 = 0.3;
+
+    for (particles, mut solution) in generate_simple_test_cases(search_radius) {
+        let mut nl = FlatNeighborhoodList::default();
+        let mut domain = Aabb3d::from_points(particles.as_slice());
+        domain.grow_uniformly(search_radius);
+        neighborhood_search_spatial_hashing_flat::<i32, f32>(
+            &domain,
+            particles.as_slice(),
+            search_radius,
+            &mut nl,
+        );
+        let mut nl = nl.to_vec_vec();
+
+        sort_neighborhood_lists(&mut nl);
+        sort_neighborhood_lists(&mut solution);
+
+        assert_eq!(
+            nl, solution,
+            "neighborhood_search_spatial_hashing failed. Search radius: {}, input: {:?}",
+            search_radius, particles
+        );
+    }
+}
+
+#[test]
 fn test_neighborhood_search_spatial_hashing_parallel_simple() {
     let search_radius: f32 = 0.3;
 
@@ -166,6 +193,7 @@ mod tests_from_files {
         let mut nl_naive = Vec::new();
         let mut nl_hashed = Vec::new();
         let mut nl_hashed_par = Vec::new();
+        let mut nl_hashed_flat = FlatNeighborhoodList::default();
 
         neighborhood_search_naive(particles.as_slice(), search_radius, &mut nl_naive);
         neighborhood_search_spatial_hashing::<i64, f32>(
@@ -180,13 +208,22 @@ mod tests_from_files {
             search_radius,
             &mut nl_hashed_par,
         );
+        neighborhood_search_spatial_hashing_flat::<i64, f32>(
+            &domain,
+            particles.as_slice(),
+            search_radius,
+            &mut nl_hashed_flat,
+        );
 
         sort_neighborhood_lists(&mut nl_naive);
         sort_neighborhood_lists(&mut nl_hashed);
         sort_neighborhood_lists(&mut nl_hashed_par);
+        let mut nl_hashed_flat = nl_hashed_flat.to_vec_vec();
+        sort_neighborhood_lists(&mut nl_hashed_flat);
 
         assert_eq!(nl_hashed, nl_naive, "result of neighborhood_search_spatial_hashing does not match neighborhood_search_naive, file: {:?}", file);
         assert_eq!(nl_hashed_par, nl_naive, "result of neighborhood_search_spatial_hashing_parallel does not match neighborhood_search_naive, file: {:?}", file);
+        assert_eq!(nl_hashed_flat, nl_naive, "result of neighborhood_search_spatial_hashing_flat does not match neighborhood_search_naive, file: {:?}", file);
     }
 
     #[test]
@@ -203,6 +240,7 @@ mod tests_from_files {
         let mut nl_naive = Vec::new();
         let mut nl_hashed = Vec::new();
         let mut nl_hashed_par = Vec::new();
+        let mut nl_hashed_flat = FlatNeighborhoodList::default();
 
         neighborhood_search_naive(particles.as_slice(), search_radius, &mut nl_naive);
         neighborhood_search_spatial_hashing::<i64, f32>(
@@ -217,13 +255,22 @@ mod tests_from_files {
             search_radius,
             &mut nl_hashed_par,
         );
+        neighborhood_search_spatial_hashing_flat::<i64, f32>(
+            &domain,
+            particles.as_slice(),
+            search_radius,
+            &mut nl_hashed_flat,
+        );
 
         sort_neighborhood_lists(&mut nl_naive);
         sort_neighborhood_lists(&mut nl_hashed);
         sort_neighborhood_lists(&mut nl_hashed_par);
+        let mut nl_hashed_flat = nl_hashed_flat.to_vec_vec();
+        sort_neighborhood_lists(&mut nl_hashed_flat);
 
         assert_eq!(nl_hashed, nl_naive, "result of neighborhood_search_spatial_hashing does not match neighborhood_search_naive, file: {:?}", file);
         assert_eq!(nl_hashed_par, nl_naive, "result of neighborhood_search_spatial_hashing_parallel does not match neighborhood_search_naive, file: {:?}", file);
+        assert_eq!(nl_hashed_flat, nl_naive, "result of neighborhood_search_spatial_hashing_flat does not match neighborhood_search_naive, file: {:?}", file);
     }
 
     #[test]
@@ -240,6 +287,7 @@ mod tests_from_files {
         let mut nl_naive = Vec::new();
         let mut nl_hashed = Vec::new();
         let mut nl_hashed_par = Vec::new();
+        let mut nl_hashed_flat = FlatNeighborhoodList::default();
 
         neighborhood_search_naive(particles.as_slice(), search_radius, &mut nl_naive);
         neighborhood_search_spatial_hashing::<i64, f32>(
@@ -254,12 +302,21 @@ mod tests_from_files {
             search_radius,
             &mut nl_hashed_par,
         );
+        neighborhood_search_spatial_hashing_flat::<i64, f32>(
+            &domain,
+            particles.as_slice(),
+            search_radius,
+            &mut nl_hashed_flat,
+        );
 
         sort_neighborhood_lists(&mut nl_naive);
         sort_neighborhood_lists(&mut nl_hashed);
         sort_neighborhood_lists(&mut nl_hashed_par);
+        let mut nl_hashed_flat = nl_hashed_flat.to_vec_vec();
+        sort_neighborhood_lists(&mut nl_hashed_flat);
 
         assert_eq!(nl_hashed, nl_naive, "result of neighborhood_search_spatial_hashing does not match neighborhood_search_naive, file: {:?}", file);
         assert_eq!(nl_hashed_par, nl_naive, "result of neighborhood_search_spatial_hashing_parallel does not match neighborhood_search_naive, file: {:?}", file);
+        assert_eq!(nl_hashed_flat, nl_naive, "result of neighborhood_search_spatial_hashing_flat does not match neighborhood_search_naive, file: {:?}", file);
     }
 }


### PR DESCRIPTION
- Special handling for "very sparse domains" (domains with less than 5% particles of largest domain) by keeping track of all cubes with at least one edge above the surface threshold
- Compute neighbor lists and densities only for particles inside of the subdomain (ghost particle values will be computed by other subdomains)
- Use flat vectors for serial neighbor list computation instead of nested `Vec`s