### PR TITLE
Removed all redundant calls to .clone().

### DIFF
--- a/splashsurf_lib/src/aabb.rs
+++ b/splashsurf_lib/src/aabb.rs
@@ -30,9 +30,9 @@ where
         if points.is_empty() {
             Self::zeros()
         } else if points.len() == 1 {
-            Self::from_point(points[0].clone())
+            Self::from_point(points[0])
         } else {
-            let initial_aabb = Self::from_point(points[0].clone());
+            let initial_aabb = Self::from_point(points[0]);
             points[1..]
                 .par_iter()
                 .fold(
@@ -73,7 +73,7 @@ where
     #[inline(always)]
     pub fn from_point(point: SVector<R, D>) -> Self {
         Self {
-            min: point.clone(),
+            min: point,
             max: point,
         }
     }

--- a/splashsurf_lib/src/dense_subdomains.rs
+++ b/splashsurf_lib/src/dense_subdomains.rs
@@ -359,7 +359,7 @@ pub(crate) fn extract_narrow_band<I: Index, R: Real>(
         profile!("Collect narrow band positions");
         let narrow_band_positions = narrow_band
             .into_iter()
-            .map(|i| particles[i].clone())
+            .map(|i| particles[i])
             .collect::<Vec<_>>();
         narrow_band_positions
     }
@@ -762,15 +762,15 @@ pub(crate) fn reconstruction<I: Index, R: Real>(
 
         if !is_max[0] && !is_max[1] {
             // Edge is already in the correct subdomain
-            (subdomain_index, local_edge.clone())
+            (subdomain_index, *local_edge)
         } else {
             // We have to translate to the neighboring subdomain (+1 in all directions where is_max == true)
             let subdomain_cell = subdomain_grid
                 .try_unflatten_cell_index(subdomain_index)
                 .expect("invalid subdomain index");
 
-            let mut target_subdomain_ijk = subdomain_cell.index().clone();
-            let mut target_local_origin_ijk = local_edge.origin().index().clone();
+            let mut target_subdomain_ijk = *subdomain_cell.index();
+            let mut target_local_origin_ijk = *local_edge.origin().index();
 
             // Obtain index of new subdomain and new origin point
             for (&orth_axis, &is_max) in local_edge
@@ -932,8 +932,8 @@ pub(crate) fn reconstruction<I: Index, R: Real>(
                             // Use global coordinate calculation for consistency with neighboring domains
                             let global_point_ijk = local_to_global_point_ijk(
                                 point_ijk,
-                                subdomain_ijk.clone(),
-                                mc_cells_per_subdomain.clone(),
+                                *subdomain_ijk,
+                                *mc_cells_per_subdomain,
                             );
                             let global_point = parameters
                                 .global_marching_cubes_grid
@@ -1185,8 +1185,8 @@ pub(crate) fn reconstruction<I: Index, R: Real>(
                             // Use global coordinate calculation for consistency with neighboring domains
                             let global_point_ijk = local_to_global_point_ijk(
                                 point_ijk,
-                                subdomain_ijk.clone(),
-                                mc_cells_per_subdomain.clone(),
+                                *subdomain_ijk,
+                                *mc_cells_per_subdomain,
                             );
                             let global_point = parameters
                                 .global_marching_cubes_grid
@@ -1464,7 +1464,7 @@ pub(crate) fn stitching<I: Index, R: Real>(
                                 .for_each(
                                     |(_exterior_local_idx, ((old_local_idx, vert), edge_index))| {
                                         let global_index = *exterior_vertex_mapping
-                                            .entry(edge_index.clone())
+                                            .entry(*edge_index)
                                             .or_insert_with(|| {
                                                 // Exterior vertices will come after all interior vertices in the mesh
                                                 let global_index = total_interior_vert_count
@@ -1795,7 +1795,7 @@ pub(crate) mod debug {
             let subdomain_ijk = subdomain_grid
                 .try_unflatten_cell_index(flat_subdomain_idx as I)
                 .unwrap();
-            let [i, j, k] = subdomain_ijk.index().clone();
+            let [i, j, k] = *subdomain_ijk.index();
 
             let vertex_offset = hexmesh.vertices.len();
 

--- a/splashsurf_lib/src/halfedge_mesh.rs
+++ b/splashsurf_lib/src/halfedge_mesh.rs
@@ -120,7 +120,7 @@ impl<R: Real> HalfEdgeTriMesh<R> {
         self.vertex_half_edge_map[vertex]
             .iter()
             .copied()
-            .map(|he_i| self.half_edges[he_i].clone())
+            .map(|he_i| self.half_edges[he_i])
     }
 
     /// Iterator over all incident faces of the given vertex
@@ -137,7 +137,7 @@ impl<R: Real> HalfEdgeTriMesh<R> {
         for &he_idx in from_edges {
             let he = &self.half_edges[he_idx];
             if he.to == to {
-                return Some(he.clone());
+                return Some(*he);
             }
         }
 

--- a/splashsurf_lib/src/mesh.rs
+++ b/splashsurf_lib/src/mesh.rs
@@ -428,7 +428,7 @@ fn keep_cells_impl<R: Real, MeshT: Mesh3d<R>>(
             .copied()
             .enumerate()
             .filter_map(|(i, should_keep)| if should_keep { Some(i) } else { None })
-            .map(|index| vertices[index].clone())
+            .map(|index| vertices[index])
             .collect();
 
         MeshT::from_vertices_and_connectivity(relabeled_vertices, relabeled_cells)
@@ -1391,13 +1391,13 @@ impl<R: Real> MeshAttribute<R> {
     fn keep_indices(&self, indices: &[usize]) -> Self {
         let data = match &self.data {
             AttributeData::ScalarU64(d) => {
-                AttributeData::ScalarU64(indices.iter().copied().map(|i| d[i].clone()).collect())
+                AttributeData::ScalarU64(indices.iter().copied().map(|i| d[i]).collect())
             }
             AttributeData::ScalarReal(d) => {
-                AttributeData::ScalarReal(indices.iter().copied().map(|i| d[i].clone()).collect())
+                AttributeData::ScalarReal(indices.iter().copied().map(|i| d[i]).collect())
             }
             AttributeData::Vector3Real(d) => {
-                AttributeData::Vector3Real(indices.iter().copied().map(|i| d[i].clone()).collect())
+                AttributeData::Vector3Real(indices.iter().copied().map(|i| d[i]).collect())
             }
         };
 

--- a/splashsurf_lib/src/neighborhood_search.rs
+++ b/splashsurf_lib/src/neighborhood_search.rs
@@ -523,7 +523,7 @@ pub fn neighborhood_search_spatial_hashing_parallel<I: Index, R: Real>(
 
                 let neighborhood_test =
                     |pos_i: Vector3<R>, particle_j: usize, local_buffer: &mut Vec<usize>| {
-                        let pos_j = unsafe { particle_positions.get_unchecked(particle_j).clone() };
+                        let pos_j = unsafe { *particle_positions.get_unchecked(particle_j) };
 
                         // TODO: We might not be able to guarantee that this is symmetric.
                         //  Therefore, it might be possible that only one side of some neighborhood relationships gets detected.
@@ -536,7 +536,7 @@ pub fn neighborhood_search_spatial_hashing_parallel<I: Index, R: Real>(
 
                 // Iterate over all particles of the current cell
                 for (i, particle_i) in cell_k_particles.iter().copied().enumerate() {
-                    let pos_i = unsafe { particle_positions.get_unchecked(particle_i).clone() };
+                    let pos_i = unsafe { *particle_positions.get_unchecked(particle_i) };
 
                     // Check for neighborhood with particles of all adjacent cells
                     // Transitive neighborhood relationship is not handled explicitly.

--- a/splashsurf_lib/src/postprocessing.rs
+++ b/splashsurf_lib/src/postprocessing.rs
@@ -39,7 +39,7 @@ pub fn par_laplacian_smoothing_inplace<R: Real>(
                 // Compute mean position of neighboring vertices
                 let mut vertex_sum = Vector3::zeros();
                 for j in vertex_connectivity[i].iter() {
-                    vertex_sum += vertex_buffer[j.clone()];
+                    vertex_sum += vertex_buffer[*j];
                 }
                 if vertex_connectivity[i].len() > 0 {
                     let n = R::from_usize(vertex_connectivity[i].len()).unwrap();

--- a/splashsurf_lib/src/uniform_grid.rs
+++ b/splashsurf_lib/src/uniform_grid.rs
@@ -189,7 +189,7 @@ impl<I: Index, R: Real> UniformCartesianCubeGrid3d<I, R> {
             .unscale(cell_size)
             .map(|x| x.floor())
             .scale(cell_size);
-        let aabb = Aabb3d::new(aligned_min, aabb.max().clone());
+        let aabb = Aabb3d::new(aligned_min, *aabb.max());
 
         let n_cells_real = aabb.extents() / cell_size;
         let n_cells_per_dim = Self::checked_n_cells_per_dim(&n_cells_real)
@@ -204,7 +204,7 @@ impl<I: Index, R: Real> UniformCartesianCubeGrid3d<I, R> {
         n_cells_per_dim: &[I; 3],
         cell_size: R,
     ) -> Result<Self, GridConstructionError<I, R>> {
-        let n_cells_per_dim = n_cells_per_dim.clone();
+        let n_cells_per_dim = *n_cells_per_dim;
         let n_points_per_dim = Self::checked_n_points_per_dim(&n_cells_per_dim)
             .ok_or(GridConstructionError::IndexTypeTooSmallPointsPerDim)?;
 
@@ -284,7 +284,7 @@ impl<I: Index, R: Real> UniformCartesianCubeGrid3d<I, R> {
     }
 
     pub fn get_edge(&self, origin_ijk: [I; 3], axis: Axis) -> Option<EdgeIndex<I>> {
-        let mut target_ijk = origin_ijk.clone();
+        let mut target_ijk = origin_ijk;
         target_ijk[axis.dim()] += I::one();
         if self.point_exists(&origin_ijk) && self.point_exists(&target_ijk) {
             Some(EdgeIndex {
@@ -479,7 +479,7 @@ impl<I: Index, R: Real> UniformCartesianCubeGrid3d<I, R> {
             return None;
         }
 
-        let mut neighbor_ijk = point_ijk.clone();
+        let mut neighbor_ijk = *point_ijk;
         neighbor_ijk[dim] = direction.apply_step(neighbor_ijk[dim], I::one());
         Some(PointIndex::from_ijk(neighbor_ijk))
     }
@@ -493,7 +493,7 @@ impl<I: Index, R: Real> UniformCartesianCubeGrid3d<I, R> {
         let DirectedAxis { axis, direction } = direction;
         let dim = axis.dim();
 
-        let mut neighbor_ijk = point_ijk.clone();
+        let mut neighbor_ijk = *point_ijk;
         neighbor_ijk[dim] = direction.apply_step(neighbor_ijk[dim], I::one());
         neighbor_ijk
     }
@@ -533,7 +533,7 @@ impl<I: Index, R: Real> UniformCartesianCubeGrid3d<I, R> {
 
         // Try to obtain all points that might be the origin or lower corner of a cell
         // Some of them (p1, p3 or both) might not exist if the edge is at the boundary of the grid
-        let p0 = Some(edge_start_point.clone());
+        let p0 = Some(*edge_start_point);
         let p1 = self.get_point_neighbor(edge_start_point, step_dir1);
         let p3 = self.get_point_neighbor(edge_start_point, step_dir3);
         // Get the last origin point by combining both steps
@@ -665,7 +665,7 @@ impl<I: Index, R: Real> UniformCartesianCubeGrid3d<I, R> {
                 cell_size * n_cells_per_dim[2].to_real()?,
             );
 
-        Some(Aabb3d::new(min.clone(), max))
+        Some(Aabb3d::new(*min, max))
     }
 
     fn checked_num_points(n_points_per_dim: &[I; 3]) -> Option<I> {


### PR DESCRIPTION
As identidifed by this command :-

```bash
cargo clippy --all 2>&1 | grep -A5 -B5 clone
```

I don't have an supporting benchmarks to comment on any performance improvements. Just that less cloning is better.

I have a additional qestion.

I am cherry picking a single issue from running cargo clippy but, the list of clippy warning scroll on for several pages... I would like to submit more PR's getting that list down 

If only for the fact that as the code developes the chance is missing a super critical clippy issues grows which the list of not maintained 

Would more PR's be welcome?