### PR TITLE
Minor: Removed dependency on the lazy_static crate.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -645,12 +645,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
 name = "lexical-sort"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1336,7 +1330,6 @@ dependencies = [
  "flate2",
  "fxhash",
  "itertools 0.14.0",
- "lazy_static",
  "log",
  "nalgebra",
  "nom 7.1.3",

--- a/splashsurf_lib/Cargo.toml
+++ b/splashsurf_lib/Cargo.toml
@@ -22,15 +22,12 @@ default-target = "x86_64-unknown-linux-gnu"
 targets = []
 
 # Ignore the tests (especially the test mesh files) for publishing
-exclude = [
-    "tests/*",
-    "benches/*",
-]
+exclude = ["tests/*", "benches/*"]
 
 [features]
 default = []
 vtk_extras = ["vtkio"]
-profiling = ["lazy_static"]
+profiling = []
 io = ["vtk_extras", "vtkio", "ply-rs", "nom", "serde_json", "flate2"]
 
 [dependencies]
@@ -60,13 +57,12 @@ flate2 = { version = "1.0", optional = true }
 nom = { version = "7.1.3", optional = true }
 serde_json = { version = "1.0", optional = true }
 
-# Needed for profiling feature
-lazy_static = { version = "1.4", optional = true }
-
 [dev-dependencies]
 criterion = "0.5.1"
 ultraviolet = "0.9"
-sdfu = { git = "https://github.com/w1th0utnam3/sdfu", features = ["ultraviolet"], rev = "e39a4a8685a56a3430218b9f2dfd546ab2dbe2d6" }
+sdfu = { git = "https://github.com/w1th0utnam3/sdfu", features = [
+  "ultraviolet",
+], rev = "e39a4a8685a56a3430218b9f2dfd546ab2dbe2d6" }
 
 [[bench]]
 name = "splashsurf_lib_benches"

--- a/splashsurf_lib/src/profiling.rs
+++ b/splashsurf_lib/src/profiling.rs
@@ -1,21 +1,20 @@
 //! Implementation details for the [`profile`](crate::profile) macro
 
-use lazy_static::lazy_static;
 use parking_lot::RwLock;
 use std::collections::hash_map::RandomState;
 use std::collections::{HashMap, HashSet};
 use std::error::Error;
 use std::hash::{BuildHasher, Hash};
 use std::io;
+use std::sync::LazyLock;
 use std::time::{Duration, Instant};
 use thread_local::ThreadLocal;
 
-lazy_static! {
-    /// Thread local storage of the [`Profiler`](Profiler)s storing all [`Scope`](Scope)s of the thread
-    pub static ref PROFILER: ThreadLocal<RwLock<Profiler>> = ThreadLocal::new();
-    /// `RandomState` used to obtain `Hasher`s to hash [`ScopeId`](ScopeId)s for parent/child identification
-    pub static ref RANDOM_STATE: RandomState = RandomState::new();
-}
+/// Thread local storage of the [`Profiler`](Profiler)s storing all [`Scope`](Scope)s of the thread
+pub static PROFILER: LazyLock<ThreadLocal<RwLock<Profiler>>> = LazyLock::new(ThreadLocal::new);
+
+/// `RandomState` used to obtain `Hasher`s to hash [`ScopeId`](ScopeId)s for parent/child identification
+pub static RANDOM_STATE: LazyLock<RandomState> = LazyLock::new(RandomState::new);
 
 /// Implementation of the profile macro, use [`profile`](crate::profile) instead
 #[doc(hidden)]


### PR DESCRIPTION
The Required functionality is now in the standard library

"use std::sync::LazyLock;"

Minor as the change only effects profiling.

Here is the announcement ( 2023 ) 

<https://blog.rust-lang.org/2023/06/01/Rust-1.70.0.html>