### PR TITLE
More Kernel Types

### DIFF
--- a/pysplashsurf/pysplashsurf/docs/requirements.txt
+++ b/pysplashsurf/pysplashsurf/docs/requirements.txt
@@ -1,4 +1,4 @@
-pip==25.0.1
+pip==25.2
 sphinx==8.2.3
 numpy==2.2.3
 meshio==5.3.5

--- a/pysplashsurf/src/lib.rs
+++ b/pysplashsurf/src/lib.rs
@@ -39,6 +39,7 @@ fn pysplashsurf(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<uniform_grid::PyUniformGrid>()?;
     m.add_class::<reconstruction::PySurfaceReconstruction>()?;
     m.add_class::<sph_interpolation::PySphInterpolator>()?;
+    m.add_class::<utils::KernelType>()?;
 
     use wrap_pyfunction as wrap;
 

--- a/pysplashsurf/src/pipeline.rs
+++ b/pysplashsurf/src/pipeline.rs
@@ -198,6 +198,7 @@ pub fn reconstruction_pipeline<'py>(
         enable_simd: simd,
         spatial_decomposition,
         global_neighborhood_list: false,
+        kernel_type: splashsurf_lib::kernel::KernelType::CubicSpline,
     };
 
     let postprocessing_args = splashsurf::reconstruct::ReconstructionPostprocessingParameters {

--- a/pysplashsurf/src/reconstruction.rs
+++ b/pysplashsurf/src/reconstruction.rs
@@ -181,6 +181,7 @@ pub fn reconstruct_surface<'py>(
         enable_simd: simd,
         spatial_decomposition,
         global_neighborhood_list,
+        kernel_type: splashsurf_lib::kernel::KernelType::CubicSpline,
     };
 
     let element_type = particles.dtype();

--- a/pysplashsurf/src/sph_interpolation.rs
+++ b/pysplashsurf/src/sph_interpolation.rs
@@ -11,7 +11,7 @@ use splashsurf_lib::{
     nalgebra::{Unit, Vector3},
     sph_interpolation::SphInterpolator,
 };
-
+use splashsurf_lib::kernel::KernelType;
 use crate::utils::*;
 
 enum PySphInterpolatorWrapper {
@@ -55,6 +55,7 @@ impl PySphInterpolator {
                 densities,
                 R::from_float(particle_rest_mass),
                 R::from_float(compact_support_radius),
+                KernelType::CubicSpline
             )))
         } else {
             Err(pyerr_scalar_type_mismatch())

--- a/pysplashsurf/src/sph_interpolation.rs
+++ b/pysplashsurf/src/sph_interpolation.rs
@@ -1,3 +1,4 @@
+use crate::utils::*;
 use numpy as np;
 use numpy::prelude::*;
 use numpy::{Element, PyArray1, PyArray2, PyUntypedArray};
@@ -5,14 +6,13 @@ use pyo3::PyResult;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3_stub_gen::derive::*;
+use splashsurf_lib::kernel::KernelType;
 use splashsurf_lib::nalgebra::SVector;
 use splashsurf_lib::{
     Real,
     nalgebra::{Unit, Vector3},
     sph_interpolation::SphInterpolator,
 };
-use splashsurf_lib::kernel::KernelType;
-use crate::utils::*;
 
 enum PySphInterpolatorWrapper {
     F32(SphInterpolator<f32>),
@@ -55,7 +55,7 @@ impl PySphInterpolator {
                 densities,
                 R::from_float(particle_rest_mass),
                 R::from_float(compact_support_radius),
-                KernelType::CubicSpline
+                KernelType::CubicSpline,
             )))
         } else {
             Err(pyerr_scalar_type_mismatch())

--- a/pysplashsurf/src/utils.rs
+++ b/pysplashsurf/src/utils.rs
@@ -3,8 +3,31 @@ use numpy::{Element, PyArray, PyUntypedArray};
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
 use pyo3::{Bound, PyAny, PyErr, PyResult};
+use pyo3_stub_gen::derive::gen_stub_pyclass_enum;
 use splashsurf_lib::Real;
 use splashsurf_lib::nalgebra::SVector;
+
+/// Enum for specifying the Kernel function used for the reconstruction
+#[gen_stub_pyclass_enum]
+#[pyclass]
+#[derive(Clone)]
+pub enum KernelType {
+    CubicSpline,
+    Poly6,
+    Spiky,
+    WendlandQuinticC2,
+}
+
+impl KernelType {
+    pub fn into_lib_enum(&self) -> splashsurf_lib::kernel::KernelType {
+        match self {
+            KernelType::CubicSpline => splashsurf_lib::kernel::KernelType::CubicSpline,
+            KernelType::Poly6 => splashsurf_lib::kernel::KernelType::Poly6,
+            KernelType::Spiky => splashsurf_lib::kernel::KernelType::Spiky,
+            KernelType::WendlandQuinticC2 => splashsurf_lib::kernel::KernelType::WendlandQuinticC2,
+        }
+    }
+}
 
 /// The index type used for all grids and reconstructions in this crate
 pub(crate) type IndexT = i64;

--- a/pysplashsurf/tests/test_basic.py
+++ b/pysplashsurf/tests/test_basic.py
@@ -301,7 +301,7 @@ def interpolator_test(dtype):
     rest_mass = 1000.0 * 0.025**3
 
     interpolator = pysplashsurf.SphInterpolator(
-        particles, reconstruction.particle_densities, rest_mass, compact_support
+        particles, reconstruction.particle_densities, rest_mass, compact_support, pysplashsurf.KernelType.CubicSpline
     )
 
     assert type(interpolator) is pysplashsurf.SphInterpolator

--- a/splashsurf/src/cli.rs
+++ b/splashsurf/src/cli.rs
@@ -86,7 +86,7 @@ pub(crate) enum KernelType {
     CubicSpline,
     Poly6,
     Spiky,
-    WendlandQuinticC2
+    WendlandQuinticC2,
 }
 
 impl KernelType {

--- a/splashsurf/src/cli.rs
+++ b/splashsurf/src/cli.rs
@@ -80,6 +80,26 @@ impl Switch {
     }
 }
 
+/// An enum for specifying the wanted kernel type in the CLI
+#[derive(Copy, Clone, Debug, PartialEq, Eq, clap::ValueEnum)]
+pub(crate) enum KernelType {
+    CubicSpline,
+    Poly6,
+    Spiky,
+    WendlandQuinticC2
+}
+
+impl KernelType {
+    pub(crate) fn into_lib_enum(self) -> splashsurf_lib::kernel::KernelType {
+        match self {
+            KernelType::CubicSpline => splashsurf_lib::kernel::KernelType::CubicSpline,
+            KernelType::Poly6 => splashsurf_lib::kernel::KernelType::Poly6,
+            KernelType::Spiky => splashsurf_lib::kernel::KernelType::Spiky,
+            KernelType::WendlandQuinticC2 => splashsurf_lib::kernel::KernelType::WendlandQuinticC2,
+        }
+    }
+}
+
 /// Runs the splashsurf CLI with the provided command line arguments.
 ///
 /// This function behaves like the binary `splashsurf` command line tool including output to stdout

--- a/splashsurf/src/reconstruct.rs
+++ b/splashsurf/src/reconstruct.rs
@@ -1153,7 +1153,7 @@ pub fn reconstruction_pipeline<'a, I: Index, R: Real>(
                 particle_densities,
                 particle_rest_mass,
                 params.compact_support_radius,
-                params.kernel_type
+                params.kernel_type,
             ))
         } else {
             None

--- a/splashsurf/src/reconstruct.rs
+++ b/splashsurf/src/reconstruct.rs
@@ -1,6 +1,6 @@
 //! Implementation of the `reconstruct` subcommand of the splashsurf CLI.
 
-use crate::cli::Switch;
+use crate::cli::{KernelType, Switch};
 use crate::reconstruct::arguments::*;
 use crate::{io, logging};
 use anyhow::{Context, anyhow};
@@ -135,7 +135,16 @@ pub(crate) struct ReconstructSubcommandArgs {
         require_equals = true
     )]
     pub simd: Switch,
-
+    /// Kernel that is used for the reconstruction and interpolation.
+    #[arg(
+        help_heading = ARGS_ADV,
+        long,
+        default_value = "cubic-spline",
+        value_name = "cubic-spline|poly6|spiky|wendland-quintic-c2",
+        ignore_case = true,
+        require_equals = true
+    )]
+    pub kernel: KernelType,
     /// Enable automatic spatial decomposition using a regular grid-based approach (for efficient multithreading) if the domain is large enough
     #[arg(
         help_heading = ARGS_DECOMPOSITION,
@@ -651,6 +660,7 @@ pub(crate) mod arguments {
                 enable_simd: args.simd.into_bool(),
                 spatial_decomposition,
                 global_neighborhood_list: args.mesh_smoothing_weights.into_bool(),
+                kernel_type: args.kernel.into_lib_enum(),
             };
 
             // Optionally initialize thread pool

--- a/splashsurf/src/reconstruct.rs
+++ b/splashsurf/src/reconstruct.rs
@@ -1153,6 +1153,7 @@ pub fn reconstruction_pipeline<'a, I: Index, R: Real>(
                 particle_densities,
                 particle_rest_mass,
                 params.compact_support_radius,
+                params.kernel_type
             ))
         } else {
             None

--- a/splashsurf_lib/benches/benches/bench_full.rs
+++ b/splashsurf_lib/benches/benches/bench_full.rs
@@ -105,6 +105,7 @@ pub fn surface_reconstruction_dam_break(c: &mut Criterion) {
         enable_simd: true,
         spatial_decomposition: SpatialDecomposition::None,
         global_neighborhood_list: false,
+        kernel_type: splashsurf_lib::kernel::KernelType::CubicSpline,
     };
 
     let mut group = c.benchmark_group("full surface reconstruction");
@@ -165,6 +166,7 @@ pub fn surface_reconstruction_double_dam_break(c: &mut Criterion) {
         enable_simd: true,
         spatial_decomposition: SpatialDecomposition::None,
         global_neighborhood_list: false,
+        kernel_type: splashsurf_lib::kernel::KernelType::CubicSpline,
     };
 
     let mut group = c.benchmark_group("full surface reconstruction");
@@ -225,6 +227,7 @@ pub fn surface_reconstruction_double_dam_break_inplace(c: &mut Criterion) {
         enable_simd: true,
         spatial_decomposition: SpatialDecomposition::None,
         global_neighborhood_list: false,
+        kernel_type: splashsurf_lib::kernel::KernelType::CubicSpline,
     };
 
     let mut group = c.benchmark_group("full surface reconstruction");

--- a/splashsurf_lib/benches/benches/bench_grid_loop.rs
+++ b/splashsurf_lib/benches/benches/bench_grid_loop.rs
@@ -231,7 +231,6 @@ pub fn grid_loop_avx2(c: &mut Criterion) {
     #[cfg(all(target_feature = "avx2", target_feature = "fma"))]
     {
         let avx_result = unsafe {
-            let kernel = CubicSplineKernel::new(params.compact_support_radius);
             let mut params = params.clone();
             dense_subdomains::density_grid_loop_avx(
                 params.levelset_grid.as_mut_slice(),
@@ -243,7 +242,8 @@ pub fn grid_loop_avx2(c: &mut Criterion) {
                 params.cube_radius,
                 params.squared_support_with_margin,
                 params.particle_rest_mass,
-                &kernel,
+                params.compact_support_radius,
+                splashsurf_lib::kernel::KernelType::CubicSpline,
             );
             params.levelset_grid
         };
@@ -268,7 +268,6 @@ pub fn grid_loop_avx2(c: &mut Criterion) {
     unsafe {
         group.bench_function("grid_loop_avx2", |b| {
             b.iter(|| {
-                let kernel = CubicSplineKernel::new(params.compact_support_radius);
                 let mut params = params.clone();
                 dense_subdomains::density_grid_loop_avx(
                     params.levelset_grid.as_mut_slice(),
@@ -280,7 +279,8 @@ pub fn grid_loop_avx2(c: &mut Criterion) {
                     params.cube_radius,
                     params.squared_support_with_margin,
                     params.particle_rest_mass,
-                    &kernel,
+                    params.compact_support_radius,
+                    splashsurf_lib::kernel::KernelType::CubicSpline,
                 );
             })
         });

--- a/splashsurf_lib/benches/benches/bench_grid_loop.rs
+++ b/splashsurf_lib/benches/benches/bench_grid_loop.rs
@@ -2,7 +2,7 @@ use criterion::{Criterion, criterion_group};
 use nalgebra::{Scalar, Vector3};
 use serde_derive::{Deserialize, Serialize};
 use splashsurf_lib::dense_subdomains;
-use splashsurf_lib::kernel::CubicSplineKernel;
+use splashsurf_lib::kernel::{CubicSplineKernel, SymmetricKernel3d};
 use splashsurf_lib::uniform_grid::UniformCartesianCubeGrid3d;
 use std::time::Duration;
 
@@ -243,7 +243,7 @@ pub fn grid_loop_avx2(c: &mut Criterion) {
                 params.squared_support_with_margin,
                 params.particle_rest_mass,
                 params.compact_support_radius,
-                splashsurf_lib::kernel::KernelType::CubicSpline,
+                &splashsurf_lib::kernel::KernelType::CubicSpline,
             );
             params.levelset_grid
         };
@@ -280,7 +280,7 @@ pub fn grid_loop_avx2(c: &mut Criterion) {
                     params.squared_support_with_margin,
                     params.particle_rest_mass,
                     params.compact_support_radius,
-                    splashsurf_lib::kernel::KernelType::CubicSpline,
+                    &splashsurf_lib::kernel::KernelType::CubicSpline,
                 );
             })
         });

--- a/splashsurf_lib/benches/benches/bench_mesh.rs
+++ b/splashsurf_lib/benches/benches/bench_mesh.rs
@@ -29,6 +29,7 @@ fn reconstruct_particles<P: AsRef<Path>>(particle_file: P) -> SurfaceReconstruct
             auto_disable: false,
         }),
         global_neighborhood_list: false,
+        kernel_type: splashsurf_lib::kernel::KernelType::CubicSpline,
     };
 
     reconstruct_surface::<i64, _>(particle_positions.as_slice(), &parameters).unwrap()

--- a/splashsurf_lib/benches/benches/bench_subdomain_grid.rs
+++ b/splashsurf_lib/benches/benches/bench_subdomain_grid.rs
@@ -28,6 +28,7 @@ fn parameters_canyon() -> Parameters<f32> {
             auto_disable: false,
         }),
         global_neighborhood_list: false,
+        kernel_type: splashsurf_lib::kernel::KernelType::CubicSpline,
     }
 }
 

--- a/splashsurf_lib/src/dense_subdomains.rs
+++ b/splashsurf_lib/src/dense_subdomains.rs
@@ -493,7 +493,7 @@ pub(crate) fn decomposition<
     })
 }
 
-pub(crate) fn compute_global_densities_and_neighbors<I: Index, R: Real>(
+pub(crate) fn compute_global_densities_and_neighbors<I: Index, R: Real, K: SymmetricKernel3d<R>>(
     parameters: &ParametersSubdomainGrid<I, R>,
     global_particles: &[Vector3<R>],
     subdomains: &Subdomains<I>,
@@ -583,7 +583,7 @@ pub(crate) fn compute_global_densities_and_neighbors<I: Index, R: Real>(
                 |i| is_inside[i],
             );
 
-            sequential_compute_particle_densities_filtered::<I, R, _>(
+            sequential_compute_particle_densities_filtered::<I, R, _, K>(
                 subdomain_particles,
                 neighborhood_lists,
                 parameters.compact_support_radius,
@@ -1212,7 +1212,7 @@ pub fn density_grid_loop_sparse<I: Index, R: Real, K: SymmetricKernel3d<R>>(
     }
 }
 
-pub(crate) fn reconstruct_subdomains<I: Index, R: Real>(
+pub(crate) fn reconstruct_subdomains<I: Index, R: Real, K: SymmetricKernel3d<R> + Sync>(
     parameters: &ParametersSubdomainGrid<I, R>,
     global_particles: &[Vector3<R>],
     global_particle_densities: &[R],
@@ -1228,7 +1228,7 @@ pub(crate) fn reconstruct_subdomains<I: Index, R: Real>(
     let cube_radius = I::from((parameters.compact_support_radius / parameters.cube_size).ceil())
         .expect("kernel radius in cubes has to fit in index type");
     // Kernel
-    let kernel = CubicSplineKernel::new(parameters.compact_support_radius);
+    let kernel = K::new(parameters.compact_support_radius);
     //let kernel = DiscreteSquaredDistanceCubicKernel::new::<f64>(1000, parameters.compact_support_radius);
 
     let mc_total_cells = parameters.subdomain_cubes.cubed();

--- a/splashsurf_lib/src/dense_subdomains.rs
+++ b/splashsurf_lib/src/dense_subdomains.rs
@@ -16,7 +16,10 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use thread_local::ThreadLocal;
 
 use crate::density_map::sequential_compute_particle_densities_filtered;
-use crate::kernel::{CubicSplineKernel, KernelType, Poly6Kernel, SpikyKernel, SymmetricKernel3d, WendlandQuinticC2Kernel};
+use crate::kernel::{
+    CubicSplineKernel, KernelType, Poly6Kernel, SpikyKernel, SymmetricKernel3d,
+    WendlandQuinticC2Kernel,
+};
 use crate::marching_cubes::marching_cubes_lut::marching_cubes_triangulation_iter;
 use crate::mesh::{HexMesh3d, TriMesh3d};
 use crate::neighborhood_search::{
@@ -726,7 +729,7 @@ pub fn density_grid_loop_auto(
     squared_support_with_margin: f32,
     particle_rest_mass: f32,
     kernel_support: f32,
-    kernel_type: &KernelType
+    kernel_type: &KernelType,
 ) {
     #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
     {
@@ -787,7 +790,7 @@ pub fn density_grid_loop_auto(
                 particle_rest_mass,
                 &CubicSplineKernel::new(kernel_support),
             );
-        },
+        }
         KernelType::Poly6 => {
             density_grid_loop_scalar::<i64, f32, Poly6Kernel<f32>>(
                 levelset_grid,
@@ -801,7 +804,7 @@ pub fn density_grid_loop_auto(
                 particle_rest_mass,
                 &Poly6Kernel::new(kernel_support),
             );
-        },
+        }
         KernelType::Spiky => {
             density_grid_loop_scalar::<i64, f32, SpikyKernel<f32>>(
                 levelset_grid,
@@ -815,7 +818,7 @@ pub fn density_grid_loop_auto(
                 particle_rest_mass,
                 &SpikyKernel::new(kernel_support),
             );
-        },
+        }
         KernelType::WendlandQuinticC2 => {
             density_grid_loop_scalar::<i64, f32, WendlandQuinticC2Kernel<f32>>(
                 levelset_grid,
@@ -829,9 +832,8 @@ pub fn density_grid_loop_auto(
                 particle_rest_mass,
                 &WendlandQuinticC2Kernel::new(kernel_support),
             );
-        },
+        }
     }
-
 }
 
 pub fn density_grid_loop_scalar<I: Index, R: Real, K: SymmetricKernel3d<R>>(
@@ -914,8 +916,8 @@ pub fn density_grid_loop_neon(
     kernel_support: f32,
     kernel_type: &KernelType,
 ) {
-    use core::arch::aarch64::*;
     use crate::kernel::NeonKernel;
+    use core::arch::aarch64::*;
     const LANES: usize = 4;
 
     // Ensure that we can safely compute global MC vertex positions via u32 indices per dimension
@@ -1053,8 +1055,8 @@ pub fn density_grid_loop_neon(
             }
         }
     }
-    
-    match kernel_type { 
+
+    match kernel_type {
         KernelType::CubicSpline => {
             density_grid_loop::<kernel::CubicSplineKernelNeonF32>(
                 levelset_grid,
@@ -1068,7 +1070,7 @@ pub fn density_grid_loop_neon(
                 particle_rest_mass,
                 kernel_support,
             );
-        },
+        }
         KernelType::Poly6 => {
             density_grid_loop::<kernel::Poly6KernelNeonF32>(
                 levelset_grid,
@@ -1082,7 +1084,7 @@ pub fn density_grid_loop_neon(
                 particle_rest_mass,
                 kernel_support,
             );
-        },
+        }
         KernelType::Spiky => {
             density_grid_loop::<kernel::SpikyKernelNeonF32>(
                 levelset_grid,
@@ -1096,7 +1098,7 @@ pub fn density_grid_loop_neon(
                 particle_rest_mass,
                 kernel_support,
             );
-        },
+        }
         KernelType::WendlandQuinticC2 => {
             density_grid_loop::<kernel::WendlandQuinticC2KernelNeonF32>(
                 levelset_grid,
@@ -1110,7 +1112,7 @@ pub fn density_grid_loop_neon(
                 particle_rest_mass,
                 kernel_support,
             );
-        },
+        }
     }
 }
 
@@ -1133,7 +1135,7 @@ pub fn density_grid_loop_avx(
     use core::arch::x86::*;
     #[cfg(target_arch = "x86_64")]
     use core::arch::x86_64::*;
-    
+
     use crate::kernel::AvxKernel;
 
     const LANES: usize = 8;
@@ -1252,7 +1254,8 @@ pub fn density_grid_loop_avx(
                         let w_ij = evaluate_contribution(k, grid_xs, grid_ys);
 
                         unsafe {
-                            let prev_val = _mm256_loadu_ps(levelset_grid.as_ptr().add(flat_point_idx));
+                            let prev_val =
+                                _mm256_loadu_ps(levelset_grid.as_ptr().add(flat_point_idx));
                             let val = _mm256_fmadd_ps(w_ij, v_i_ps, prev_val);
                             _mm256_storeu_ps(levelset_grid.as_mut_ptr().add(flat_point_idx), val);
                         }
@@ -1290,7 +1293,7 @@ pub fn density_grid_loop_avx(
                 particle_rest_mass,
                 kernel_support,
             );
-        },
+        }
         KernelType::Poly6 => {
             density_grid_loop::<kernel::Poly6KernelAvxF32>(
                 levelset_grid,
@@ -1304,7 +1307,7 @@ pub fn density_grid_loop_avx(
                 particle_rest_mass,
                 kernel_support,
             );
-        },
+        }
         KernelType::Spiky => {
             density_grid_loop::<kernel::SpikyKernelAvxF32>(
                 levelset_grid,
@@ -1318,7 +1321,7 @@ pub fn density_grid_loop_avx(
                 particle_rest_mass,
                 kernel_support,
             );
-        },
+        }
         KernelType::WendlandQuinticC2 => {
             density_grid_loop::<kernel::WendlandQuinticC2KernelAvxF32>(
                 levelset_grid,
@@ -1332,7 +1335,7 @@ pub fn density_grid_loop_avx(
                 particle_rest_mass,
                 kernel_support,
             );
-        },
+        }
     }
 }
 

--- a/splashsurf_lib/src/density_map.rs
+++ b/splashsurf_lib/src/density_map.rs
@@ -127,7 +127,12 @@ fn init_density_storage<R: Real>(densities: &mut Vec<R>, new_len: usize) {
 
 /// Computes the individual densities of particles using a standard SPH sum, sequential implementation
 #[inline(never)]
-pub fn sequential_compute_particle_densities<I: Index, R: Real, Nl: NeighborhoodList + ?Sized, K: SymmetricKernel3d<R>>(
+pub fn sequential_compute_particle_densities<
+    I: Index,
+    R: Real,
+    Nl: NeighborhoodList + ?Sized,
+    K: SymmetricKernel3d<R>,
+>(
     particle_positions: &[Vector3<R>],
     particle_neighbor_lists: &Nl,
     compact_support_radius: R,
@@ -379,12 +384,13 @@ pub fn sequential_generate_sparse_density_map<I: Index, R: Real, K: SymmetricKer
 
     let mut sparse_densities = new_map();
 
-    let density_map_generator: SparseDensityMapGenerator<I, R, K> = SparseDensityMapGenerator::try_new(
-        grid,
-        compact_support_radius,
-        cube_size,
-        particle_rest_mass,
-    )?;
+    let density_map_generator: SparseDensityMapGenerator<I, R, K> =
+        SparseDensityMapGenerator::try_new(
+            grid,
+            compact_support_radius,
+            cube_size,
+            particle_rest_mass,
+        )?;
 
     let process_particle = |particle_data: (&Vector3<R>, R)| {
         let (particle, particle_density) = particle_data;
@@ -429,12 +435,13 @@ pub fn parallel_generate_sparse_density_map<I: Index, R: Real, K: SymmetricKerne
 
     // Generate thread local density maps
     {
-        let density_map_generator: SparseDensityMapGenerator<I, R, K> = SparseDensityMapGenerator::try_new(
-            grid,
-            compact_support_radius,
-            cube_size,
-            particle_rest_mass,
-        )?;
+        let density_map_generator: SparseDensityMapGenerator<I, R, K> =
+            SparseDensityMapGenerator::try_new(
+                grid,
+                compact_support_radius,
+                cube_size,
+                particle_rest_mass,
+            )?;
 
         profile!("generate thread local maps");
 

--- a/splashsurf_lib/src/kernel.rs
+++ b/splashsurf_lib/src/kernel.rs
@@ -197,7 +197,7 @@ unsafe impl NeonKernel for CubicSplineKernelNeonF32 {
 
     /// Evaluates the cubic spline kernel at the specified radial distances
     #[target_feature(enable = "neon")]
-    fn evaluate(&self, r: float32x4_t) -> float32x4_t {
+    unsafe fn evaluate(&self, r: float32x4_t) -> float32x4_t {
         use core::arch::aarch64::*;
 
         let one = vdupq_n_f32(1.0);

--- a/splashsurf_lib/src/kernel.rs
+++ b/splashsurf_lib/src/kernel.rs
@@ -9,8 +9,8 @@
 //!  - `SpikyKernelNeonF32`
 //!  - `WendlandQuinticC2KernelAvxF32`
 //!  - `WendlandQuinticC2KernelNeonF32`
-//! 
-//! The Avx implementations are only available on `x86` and `x86_64` targets and require AVX2 and FMA support. 
+//!
+//! The Avx implementations are only available on `x86` and `x86_64` targets and require AVX2 and FMA support.
 //! Similarly, the Neon implementations are only available on `aarch64` targets and require NEON support.
 //!
 //! Note that documentation of the SIMD kernels is only available on the respective target architectures.
@@ -352,7 +352,7 @@ impl<R: Real> SymmetricKernel3d<R> for Poly6Kernel<R> {
     #[replace_float_literals(R::from_float(literal))]
     fn new(compact_support_radius: R) -> Self {
         let h = compact_support_radius;
-        let sigma = 315.0/(64.0*R::pi()*h.powi(9));
+        let sigma = 315.0 / (64.0 * R::pi() * h.powi(9));
 
         Self {
             compact_support_radius,
@@ -366,11 +366,11 @@ impl<R: Real> SymmetricKernel3d<R> for Poly6Kernel<R> {
 
     /// Evaluates the poly6 kernel at the radial distance `r`
     fn evaluate(&self, r: R) -> R {
-        let r2 = r*r;
+        let r2 = r * r;
         let h2 = self.compact_support_radius.powi(2);
         if r2 <= h2 {
             self.normalization * (h2 - r2).powi(3)
-        }else {
+        } else {
             R::zero()
         }
     }
@@ -392,7 +392,7 @@ impl<R: Real> SymmetricKernel3d<R> for Poly6Kernel<R> {
 
     /// Evaluates the norm of the gradient of the poly6 kernel at the radial distance `r`
     fn evaluate_gradient_norm(&self, r: R) -> R {
-        let r2 = r*r;
+        let r2 = r * r;
         let h2 = self.compact_support_radius.powi(2);
 
         if r2 <= h2 {
@@ -416,9 +416,9 @@ impl Poly6KernelNeonF32 {
     pub fn new(compact_support_radius: f32) -> Self {
         let r = compact_support_radius;
         let r9 = r.powi(9);
-        let sigma = 315.0/(64.0*std::f32::consts::PI*r9);
+        let sigma = 315.0 / (64.0 * std::f32::consts::PI * r9);
         Self {
-            squared_compact_support: r*r,
+            squared_compact_support: r * r,
             sigma,
         }
     }
@@ -464,9 +464,9 @@ impl Poly6KernelAvxF32 {
     pub fn new(compact_support_radius: f32) -> Self {
         let r = compact_support_radius;
         let r9 = r.powi(9);
-        let sigma = 315.0/(64.0*std::f32::consts::PI*r9);
+        let sigma = 315.0 / (64.0 * std::f32::consts::PI * r9);
         Self {
-            squared_compact_support: r*r,
+            squared_compact_support: r * r,
             sigma,
         }
     }
@@ -513,7 +513,7 @@ impl<R: Real> SymmetricKernel3d<R> for SpikyKernel<R> {
     #[replace_float_literals(R::from_float(literal))]
     fn new(compact_support_radius: R) -> Self {
         let h = compact_support_radius;
-        let sigma = 15.0/(R::pi()*h.powi(6));
+        let sigma = 15.0 / (R::pi() * h.powi(6));
 
         Self {
             compact_support_radius,
@@ -527,11 +527,11 @@ impl<R: Real> SymmetricKernel3d<R> for SpikyKernel<R> {
 
     /// Evaluates the spiky kernel at the radial distance `r`
     fn evaluate(&self, r: R) -> R {
-        let r2 = r*r;
+        let r2 = r * r;
         let h2 = self.compact_support_radius.powi(2);
         if r2 <= h2 {
             self.normalization * (self.compact_support_radius - r).powi(3)
-        }else {
+        } else {
             R::zero()
         }
     }
@@ -547,7 +547,11 @@ impl<R: Real> SymmetricKernel3d<R> for SpikyKernel<R> {
             // normalize x
             let x = x.unscale(r);
 
-            x.scale(R::from_float(-3.0) * self.normalization * (self.compact_support_radius - r).powi(2))
+            x.scale(
+                R::from_float(-3.0)
+                    * self.normalization
+                    * (self.compact_support_radius - r).powi(2),
+            )
         } else {
             x.scale(R::zero())
         }
@@ -555,7 +559,7 @@ impl<R: Real> SymmetricKernel3d<R> for SpikyKernel<R> {
 
     /// Evaluates the norm of the gradient of the spiky kernel at the radial distance `r`
     fn evaluate_gradient_norm(&self, r: R) -> R {
-        let r2 = r*r;
+        let r2 = r * r;
         let h2 = self.compact_support_radius.powi(2);
 
         if r2 <= h2 {
@@ -579,7 +583,7 @@ impl SpikyKernelNeonF32 {
     pub fn new(compact_support_radius: f32) -> Self {
         let r = compact_support_radius;
         let r6 = r.powi(6);
-        let sigma = 15.0/(std::f32::consts::PI*r6);
+        let sigma = 15.0 / (std::f32::consts::PI * r6);
         Self {
             compact_support: r,
             sigma,
@@ -628,7 +632,7 @@ impl SpikyKernelAvxF32 {
     pub fn new(compact_support_radius: f32) -> Self {
         let r = compact_support_radius;
         let r6 = r.powi(6);
-        let sigma = 15.0/(std::f32::consts::PI*r6);
+        let sigma = 15.0 / (std::f32::consts::PI * r6);
         Self {
             compact_support: r,
             sigma,
@@ -678,7 +682,7 @@ impl<R: Real> SymmetricKernel3d<R> for WendlandQuinticC2Kernel<R> {
     #[replace_float_literals(R::from_float(literal))]
     fn new(compact_support_radius: R) -> Self {
         let h = compact_support_radius;
-        let sigma = 21.0/(2.0*R::pi()*h.powi(3));
+        let sigma = 21.0 / (2.0 * R::pi() * h.powi(3));
 
         Self {
             compact_support_radius,
@@ -695,7 +699,7 @@ impl<R: Real> SymmetricKernel3d<R> for WendlandQuinticC2Kernel<R> {
         let q = r / self.compact_support_radius;
         if q <= R::one() {
             self.normalization * (R::one() - q).powi(4) * (R::from_float(4.0) * q + R::one())
-        }else {
+        } else {
             R::zero()
         }
     }
@@ -742,7 +746,7 @@ impl WendlandQuinticC2KernelNeonF32 {
         let r = compact_support_radius;
         let compact_support_inv = 1.0 / r;
         let r3 = r.powi(3);
-        let sigma = 21.0/(2.0*std::f32::consts::PI*r3);
+        let sigma = 21.0 / (2.0 * std::f32::consts::PI * r3);
 
         Self {
             compact_support_inv,
@@ -797,7 +801,7 @@ impl WendlandQuinticC2KernelAvxF32 {
         let r = compact_support_radius;
         let compact_support_inv = 1.0 / r;
         let r3 = r.powi(3);
-        let sigma = 21.0/(2.0*std::f32::consts::PI*r3);
+        let sigma = 21.0 / (2.0 * std::f32::consts::PI * r3);
 
         Self {
             compact_support_inv,
@@ -867,7 +871,8 @@ mod kernel_tests {
                     for j in -n..n {
                         for k in -n..n {
                             let r_in = Vector3::new(i as f64, j as f64, k as f64) * dr;
-                            let r_out = Vector3::new((i + 1) as f64, (j + 1) as f64, (k + 1) as f64) * dr;
+                            let r_out =
+                                Vector3::new((i + 1) as f64, (j + 1) as f64, (k + 1) as f64) * dr;
                             let r = ((r_in + r_out) * 0.5).norm();
 
                             integral += dvol * kernel.evaluate(r);

--- a/splashsurf_lib/src/kernel.rs
+++ b/splashsurf_lib/src/kernel.rs
@@ -140,45 +140,6 @@ impl<R: Real> SymmetricKernel3d<R> for CubicSplineKernel<R> {
     }
 }
 
-#[test]
-fn test_cubic_kernel_r_compact_support() {
-    let hs = [0.025, 0.1, 2.0];
-    for &h in hs.iter() {
-        let kernel = CubicSplineKernel::new(h);
-        assert_eq!(kernel.evaluate(h), 0.0);
-        assert_eq!(kernel.evaluate(2.0 * h), 0.0);
-        assert_eq!(kernel.evaluate(10.0 * h), 0.0);
-    }
-}
-
-#[test]
-fn test_cubic_kernel_r_integral() {
-    let hs = [0.025, 0.1, 2.0];
-    let n = 10;
-
-    for &h in hs.iter() {
-        let kernel = CubicSplineKernel::new(h);
-
-        let dr = h / (n as f64);
-        let dvol = dr * dr * dr;
-
-        let mut integral = 0.0;
-        for i in -n..n {
-            for j in -n..n {
-                for k in -n..n {
-                    let r_in = Vector3::new(i as f64, j as f64, k as f64) * dr;
-                    let r_out = Vector3::new((i + 1) as f64, (j + 1) as f64, (k + 1) as f64) * dr;
-                    let r = ((r_in + r_out) * 0.5).norm();
-
-                    integral += dvol * kernel.evaluate(r);
-                }
-            }
-        }
-
-        assert!((integral - 1.0).abs() <= 1e-5);
-    }
-}
-
 /// Vectorized implementation of the cubic spline kernel using NEON instructions. Only available on `aarch64` targets.
 #[cfg(target_arch = "aarch64")]
 pub struct CubicSplineKernelNeonF32 {
@@ -232,88 +193,6 @@ impl CubicSplineKernelNeonF32 {
         // Select inner for q <= 0.5, else outer; v was clamped so q > 1 yields 0 automatically
         let leq_than_half = vcleq_f32(q, half);
         vbslq_f32(leq_than_half, res_inner, res_outer)
-    }
-}
-
-#[test]
-#[cfg_attr(
-    not(all(target_arch = "aarch64", target_feature = "neon")),
-    ignore = "Skipped on non-aarch64 targets"
-)]
-fn test_cubic_spline_kernel_neon() {
-    #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
-    {
-        use core::arch::aarch64::*;
-
-        // Test a few representative compact support radii
-        let hs: [f32; 3] = [0.025, 0.1, 2.0];
-        for &h in hs.iter() {
-            let scalar = CubicSplineKernel::new(h);
-            let neon = CubicSplineKernelNeonF32::new(h);
-
-            // Sample radii from 0 to 2h (beyond support should be 0)
-            let n: usize = 1024;
-            let mut r0: f32 = 0.0;
-            let dr: f32 = (2.0 * h) / (n as f32);
-
-            for _chunk in 0..(n / 4) {
-                // Prepare 4 lanes of radii
-                let rs = [r0, r0 + dr, r0 + 2.0 * dr, r0 + 3.0 * dr];
-                let r_vec = unsafe { vld1q_f32(rs.as_ptr()) };
-
-                // Evaluate NEON and store back to array
-                let w_vec = unsafe { neon.evaluate(r_vec) };
-                let mut w_neon = [0.0f32; 4];
-                unsafe { vst1q_f32(w_neon.as_mut_ptr(), w_vec) };
-
-                // Compare against scalar lane-wise
-                for lane in 0..4 {
-                    let r_lane = rs[lane];
-                    let w_scalar = scalar.evaluate(r_lane);
-                    let diff = (w_neon[lane] - w_scalar).abs();
-
-                    // Absolute tolerance with mild relative component to be robust across scales
-                    let tol = 5e-6_f32.max(2e-5_f32 * w_scalar.abs());
-                    assert!(
-                        diff <= tol,
-                        "NEON kernel mismatch (h={}, r={}, lane={}): neon={}, scalar={}, diff={}, tol={}",
-                        h,
-                        r_lane,
-                        lane,
-                        w_neon[lane],
-                        w_scalar,
-                        diff,
-                        tol
-                    );
-                }
-
-                r0 += 4.0 * dr;
-            }
-
-            // Also check a couple of out-of-support points explicitly
-            for &r in &[h * 1.01, h * 1.5, h * 2.0, h * 2.5] {
-                let w_scalar = scalar.evaluate(r);
-                let w_neon = {
-                    let v = unsafe { vld1q_f32([r, r, r, r].as_ptr()) };
-                    let w = unsafe { neon.evaluate(v) };
-                    let mut tmp = [0.0f32; 4];
-                    unsafe { vst1q_f32(tmp.as_mut_ptr(), w) };
-                    tmp[0]
-                };
-                let diff = (w_neon - w_scalar).abs();
-                let tol = 5e-6_f32.max(1e-5_f32 * w_scalar.abs());
-                assert!(
-                    diff <= tol,
-                    "NEON kernel mismatch outside support (h={}, r={}): neon={}, scalar={}, diff={}, tol={}",
-                    h,
-                    r,
-                    w_neon,
-                    w_scalar,
-                    diff,
-                    tol
-                );
-            }
-        }
     }
 }
 
@@ -375,108 +254,6 @@ impl CubicSplineKernelAvxF32 {
         // Select inner for q <= 0.5, else outer
         let leq_than_half = _mm256_cmp_ps::<_CMP_LE_OQ>(q, half);
         _mm256_blendv_ps(res_outer, res_inner, leq_than_half)
-    }
-}
-
-#[test]
-#[cfg_attr(
-    not(all(
-        any(target_arch = "x86_64", target_arch = "x86"),
-        target_feature = "avx2",
-        target_feature = "fma"
-    )),
-    ignore = "Skipped on non-x86 targets"
-)]
-fn test_cubic_spline_kernel_avx() {
-    #[cfg(all(
-        any(target_arch = "x86_64", target_arch = "x86"),
-        target_feature = "avx2",
-        target_feature = "fma"
-    ))]
-    {
-        #[cfg(target_arch = "x86")]
-        use core::arch::x86::*;
-        #[cfg(target_arch = "x86_64")]
-        use core::arch::x86_64::*;
-
-        // Test a few representative compact support radii
-        let hs: [f32; 3] = [0.025, 0.1, 2.0];
-        for &h in hs.iter() {
-            let scalar = CubicSplineKernel::new(h);
-            let avx = CubicSplineKernelAvxF32::new(h);
-
-            // Sample radii from 0 to 2h (beyond support should be 0)
-            let n: usize = 1024;
-            let mut r0: f32 = 0.0;
-            let dr: f32 = (2.0 * h) / (n as f32);
-
-            for _chunk in 0..(n / 8) {
-                // Prepare 8 lanes of radii
-                let rs = [
-                    r0,
-                    r0 + dr,
-                    r0 + 2.0 * dr,
-                    r0 + 3.0 * dr,
-                    r0 + 4.0 * dr,
-                    r0 + 5.0 * dr,
-                    r0 + 6.0 * dr,
-                    r0 + 7.0 * dr,
-                ];
-
-                // Evaluate AVX and store back to array
-                let r_vec = unsafe { _mm256_loadu_ps(rs.as_ptr()) };
-                let w_vec = unsafe { avx.evaluate(r_vec) };
-                let mut w_avx = [0.0f32; 8];
-                unsafe { _mm256_storeu_ps(w_avx.as_mut_ptr(), w_vec) };
-
-                // Compare against scalar lane-wise
-                for lane in 0..8 {
-                    let r_lane = rs[lane];
-                    let w_scalar = scalar.evaluate(r_lane);
-                    let diff = (w_avx[lane] - w_scalar).abs();
-
-                    // Absolute tolerance with mild relative component to be robust across scales
-                    let tol = 1e-6_f32.max(1e-5_f32 * w_scalar.abs());
-                    assert!(
-                        diff <= tol,
-                        "AVX kernel mismatch (h={}, r={}, lane={}): avx={}, scalar={}, diff={}, tol={}",
-                        h,
-                        r_lane,
-                        lane,
-                        w_avx[lane],
-                        w_scalar,
-                        diff,
-                        tol
-                    );
-                }
-
-                r0 += 8.0 * dr;
-            }
-
-            // Also check a couple of out-of-support points explicitly
-            for &r in &[h * 1.01, h * 1.5, h * 2.0, h * 2.5] {
-                let w_scalar = scalar.evaluate(r);
-                let w_avx = {
-                    let v = unsafe { _mm256_set1_ps(r) };
-                    let w = unsafe { avx.evaluate(v) };
-                    let mut tmp = [0.0f32; 8];
-                    unsafe { _mm256_storeu_ps(tmp.as_mut_ptr(), w) };
-                    tmp[0]
-                };
-                let diff = (w_avx - w_scalar).abs();
-                let tol = 1e-6_f32.max(1e-5_f32 * w_scalar.abs());
-                assert!(
-                    diff <= tol,
-                    "AVX kernel mismatch outside support (h={}, r={}): avx={}, scalar={}, diff={}, tol={}",
-                    h,
-                    r,
-                    w_avx,
-                    w_scalar,
-                    diff,
-                    tol
-                );
-            }
-        }
     }
 }
 
@@ -544,36 +321,507 @@ impl<R: Real> DiscreteSquaredDistanceCubicKernel<R> {
     }
 }
 
-#[test]
-fn test_discrete_kernel() {
-    let n = 10000;
-    let h = 0.025;
+/// Poly6 kernel
+pub struct Poly6Kernel<R: Real> {
+    /// Compact support radius of the kernel
+    compact_support_radius: R,
+    /// Kernel normalization factor (sigma)
+    normalization: R,
+}
 
-    let discrete_kernel = DiscreteSquaredDistanceCubicKernel::new::<f64>(n, h);
-    let kernel = CubicSplineKernel::new(h);
+impl<R: Real> Poly6Kernel<R> {
+    /// Initializes a poly6 kernel with the given compact support radius
+    #[replace_float_literals(R::from_float(literal))]
+    pub fn new(compact_support_radius: R) -> Self {
+        let h = compact_support_radius;
+        let sigma = 315.0/(64.0*R::pi()*h.powi(9));
 
-    // Test the pre-computed values using a linear stepping
-    let dr = h / (n as f64);
-    for i in 0..n {
-        let r = (i as f64) * dr;
-        let rr = r * r;
-
-        let discrete = discrete_kernel.evaluate(rr);
-        let continuous = kernel.evaluate(r);
-
-        let diff = (discrete - continuous).abs();
-        let rel_diff = diff / continuous;
-        if rel_diff > 5e-2 && diff > 1e-1 {
-            eprintln!(
-                "at r={}, r/h={}, discrete: {}, continuous: {}, diff: {}, rel_diff: {}",
-                r,
-                r / h,
-                discrete,
-                continuous,
-                diff,
-                rel_diff
-            );
-            assert!(false);
+        Self {
+            compact_support_radius,
+            normalization: sigma,
         }
+    }
+}
+
+impl<R: Real> SymmetricKernel3d<R> for Poly6Kernel<R> {
+    fn compact_support_radius(&self) -> R {
+        self.compact_support_radius
+    }
+
+    /// Evaluates the poly6 kernel at the radial distance `r`
+    fn evaluate(&self, r: R) -> R {
+        let r2 = r*r;
+        let h2 = self.compact_support_radius.powi(2);
+        if r2 <= h2 {
+            self.normalization * (h2 - r2).powi(3)
+        }else {
+            R::zero()
+        }
+    }
+
+    /// Evaluates the gradient of the poly6 kernel at the position `x`
+    fn evaluate_gradient(&self, x: Vector3<R>) -> Vector3<R> {
+        // Radial distance is norm of position
+        let r2 = x.norm_squared();
+        let h2 = self.compact_support_radius.powi(2);
+
+        if r2 <= h2 {
+            let x = x.normalize();
+
+            x.scale(R::from_float(6.0) * self.normalization * (h2 - r2).powi(2))
+        } else {
+            x.scale(R::zero())
+        }
+    }
+
+    /// Evaluates the norm of the gradient of the poly6 kernel at the radial distance `r`
+    fn evaluate_gradient_norm(&self, r: R) -> R {
+        let r2 = r*r;
+        let h2 = self.compact_support_radius.powi(2);
+
+        if r2 <= h2 {
+            R::from_float(6.0) * self.normalization * (h2 - r2).powi(2)
+        } else {
+            R::zero()
+        }
+    }
+}
+
+/// Spiky kernel
+pub struct SpikyKernel<R: Real> {
+    /// Compact support radius of the kernel
+    compact_support_radius: R,
+    /// Kernel normalization factor (sigma)
+    normalization: R,
+}
+
+impl<R: Real> SpikyKernel<R> {
+    /// Initializes a spiky kernel with the given compact support radius
+    #[replace_float_literals(R::from_float(literal))]
+    pub fn new(compact_support_radius: R) -> Self {
+        let h = compact_support_radius;
+        let sigma = 15.0/(R::pi()*h.powi(6));
+
+        Self {
+            compact_support_radius,
+            normalization: sigma,
+        }
+    }
+}
+
+impl<R: Real> SymmetricKernel3d<R> for SpikyKernel<R> {
+    fn compact_support_radius(&self) -> R {
+        self.compact_support_radius
+    }
+
+    /// Evaluates the spiky kernel at the radial distance `r`
+    fn evaluate(&self, r: R) -> R {
+        let r2 = r*r;
+        let h2 = self.compact_support_radius.powi(2);
+        if r2 <= h2 {
+            self.normalization * (self.compact_support_radius - r).powi(3)
+        }else {
+            R::zero()
+        }
+    }
+
+    /// Evaluates the gradient of the spiky kernel at the position `x`
+    fn evaluate_gradient(&self, x: Vector3<R>) -> Vector3<R> {
+        // Radial distance is norm of position
+        let r2 = x.norm_squared();
+        let r = r2.try_sqrt().unwrap();
+        let h2 = self.compact_support_radius.powi(2);
+
+        if r2 <= h2 {
+            // normalize x
+            let x = x.unscale(r);
+
+            x.scale(R::from_float(-3.0) * self.normalization * (self.compact_support_radius - r).powi(2))
+        } else {
+            x.scale(R::zero())
+        }
+    }
+
+    /// Evaluates the norm of the gradient of the spiky kernel at the radial distance `r`
+    fn evaluate_gradient_norm(&self, r: R) -> R {
+        let r2 = r*r;
+        let h2 = self.compact_support_radius.powi(2);
+
+        if r2 <= h2 {
+            R::from_float(-3.0) * self.normalization * (self.compact_support_radius - r).powi(2)
+        } else {
+            R::zero()
+        }
+    }
+}
+
+/// Quintic Wendland C2 kernel
+pub struct WendlandQuinticC2Kernel<R: Real> {
+    /// Compact support radius of the kernel
+    compact_support_radius: R,
+    /// Kernel normalization factor (sigma)
+    normalization: R,
+}
+
+impl<R: Real> WendlandQuinticC2Kernel<R> {
+    /// Initializes a wendland quintic C2 kernel with the given compact support radius
+    #[replace_float_literals(R::from_float(literal))]
+    pub fn new(compact_support_radius: R) -> Self {
+        let h = compact_support_radius;
+        let sigma = 21.0/(2.0*R::pi()*h.powi(3));
+
+        Self {
+            compact_support_radius,
+            normalization: sigma,
+        }
+    }
+}
+
+impl<R: Real> SymmetricKernel3d<R> for WendlandQuinticC2Kernel<R> {
+    fn compact_support_radius(&self) -> R {
+        self.compact_support_radius
+    }
+
+    /// Evaluates the wendland quintic C2 kernel at the radial distance `r`
+    fn evaluate(&self, r: R) -> R {
+        let q = r / self.compact_support_radius;
+        if q <= R::one() {
+            self.normalization * (R::one() - q).powi(4) * (R::from_float(4.0) * q + R::one())
+        }else {
+            R::zero()
+        }
+    }
+
+    /// Evaluates the gradient of the wendland quintic C2 kernel at the position `x`
+    fn evaluate_gradient(&self, x: Vector3<R>) -> Vector3<R> {
+        // Radial distance is norm of position
+        let r = x.norm();
+        let q = r / self.compact_support_radius;
+
+        if q <= R::one() {
+            // normalize x
+            let gradq = x.unscale(r * self.compact_support_radius);
+
+            gradq.scale(R::from_float(-20.0) * self.normalization * q * (R::one() - q).powi(3))
+        } else {
+            x.scale(R::zero())
+        }
+    }
+
+    /// Evaluates the norm of the gradient of the wendland quintic C2 kernel at the radial distance `r`
+    fn evaluate_gradient_norm(&self, r: R) -> R {
+        let q = r / self.compact_support_radius;
+
+        if q <= R::one() {
+            R::from_float(-20.0) * self.normalization * q * (R::one() - q).powi(3)
+        } else {
+            R::zero()
+        }
+    }
+}
+
+#[cfg(test)]
+mod kernel_tests {
+    use super::*;
+
+    macro_rules! test_kernel_r_compact_support {
+        ($kernel_class:ident) => {
+            let hs = [0.025, 0.1, 2.0];
+            for &h in hs.iter() {
+                let kernel = $kernel_class::new(h);
+                assert_eq!(kernel.evaluate(h), 0.0);
+                assert_eq!(kernel.evaluate(2.0 * h), 0.0);
+                assert_eq!(kernel.evaluate(10.0 * h), 0.0);
+            }
+        };
+    }
+
+    macro_rules! test_kernel_r_integral {
+        ($kernel_class:ident) => {
+            let hs = [0.025, 0.1, 2.0];
+            let n = 10;
+
+            for &h in hs.iter() {
+                let kernel = $kernel_class::new(h);
+
+                let dr = h / (n as f64);
+                let dvol = dr * dr * dr;
+
+                let mut integral = 0.0;
+                for i in -n..n {
+                    for j in -n..n {
+                        for k in -n..n {
+                            let r_in = Vector3::new(i as f64, j as f64, k as f64) * dr;
+                            let r_out = Vector3::new((i + 1) as f64, (j + 1) as f64, (k + 1) as f64) * dr;
+                            let r = ((r_in + r_out) * 0.5).norm();
+
+                            integral += dvol * kernel.evaluate(r);
+                        }
+                    }
+                }
+
+                // println!("{}", integral);
+                assert!((integral - 1.0).abs() <= 1e-4);
+            }
+        };
+    }
+
+    #[test]
+    fn cubic_spline_kernel_r_compact_support() {
+        test_kernel_r_compact_support!(CubicSplineKernel);
+    }
+
+    #[test]
+    fn cubic_spline_kernel_r_integral() {
+        test_kernel_r_integral!(CubicSplineKernel);
+    }
+    
+    #[test]
+    #[cfg_attr(
+        not(all(target_arch = "aarch64", target_feature = "neon")),
+        ignore = "Skipped on non-aarch64 targets"
+    )]
+    fn test_cubic_spline_kernel_neon() {
+        #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+        {
+            use core::arch::aarch64::*;
+
+            // Test a few representative compact support radii
+            let hs: [f32; 3] = [0.025, 0.1, 2.0];
+            for &h in hs.iter() {
+                let scalar = CubicSplineKernel::new(h);
+                let neon = crate::kernel::CubicSplineKernelNeonF32::new(h);
+
+                // Sample radii from 0 to 2h (beyond support should be 0)
+                let n: usize = 1024;
+                let mut r0: f32 = 0.0;
+                let dr: f32 = (2.0 * h) / (n as f32);
+
+                for _chunk in 0..(n / 4) {
+                    // Prepare 4 lanes of radii
+                    let rs = [r0, r0 + dr, r0 + 2.0 * dr, r0 + 3.0 * dr];
+                    let r_vec = unsafe { vld1q_f32(rs.as_ptr()) };
+
+                    // Evaluate NEON and store back to array
+                    let w_vec = unsafe { neon.evaluate(r_vec) };
+                    let mut w_neon = [0.0f32; 4];
+                    unsafe { vst1q_f32(w_neon.as_mut_ptr(), w_vec) };
+
+                    // Compare against scalar lane-wise
+                    for lane in 0..4 {
+                        let r_lane = rs[lane];
+                        let w_scalar = scalar.evaluate(r_lane);
+                        let diff = (w_neon[lane] - w_scalar).abs();
+
+                        // Absolute tolerance with mild relative component to be robust across scales
+                        let tol = 5e-6_f32.max(2e-5_f32 * w_scalar.abs());
+                        assert!(
+                            diff <= tol,
+                            "NEON kernel mismatch (h={}, r={}, lane={}): neon={}, scalar={}, diff={}, tol={}",
+                            h,
+                            r_lane,
+                            lane,
+                            w_neon[lane],
+                            w_scalar,
+                            diff,
+                            tol
+                        );
+                    }
+
+                    r0 += 4.0 * dr;
+                }
+
+                // Also check a couple of out-of-support points explicitly
+                for &r in &[h * 1.01, h * 1.5, h * 2.0, h * 2.5] {
+                    let w_scalar = scalar.evaluate(r);
+                    let w_neon = {
+                        let v = unsafe { vld1q_f32([r, r, r, r].as_ptr()) };
+                        let w = unsafe { neon.evaluate(v) };
+                        let mut tmp = [0.0f32; 4];
+                        unsafe { vst1q_f32(tmp.as_mut_ptr(), w) };
+                        tmp[0]
+                    };
+                    let diff = (w_neon - w_scalar).abs();
+                    let tol = 5e-6_f32.max(1e-5_f32 * w_scalar.abs());
+                    assert!(
+                        diff <= tol,
+                        "NEON kernel mismatch outside support (h={}, r={}): neon={}, scalar={}, diff={}, tol={}",
+                        h,
+                        r,
+                        w_neon,
+                        w_scalar,
+                        diff,
+                        tol
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    #[cfg_attr(
+        not(all(
+            any(target_arch = "x86_64", target_arch = "x86"),
+            target_feature = "avx2",
+            target_feature = "fma"
+        )),
+        ignore = "Skipped on non-x86 targets"
+    )]
+    fn cubic_spline_kernel_avx() {
+        #[cfg(all(
+            any(target_arch = "x86_64", target_arch = "x86"),
+            target_feature = "avx2",
+            target_feature = "fma"
+        ))]
+        {
+            #[cfg(target_arch = "x86")]
+            use core::arch::x86::*;
+            #[cfg(target_arch = "x86_64")]
+            use core::arch::x86_64::*;
+
+            // Test a few representative compact support radii
+            let hs: [f32; 3] = [0.025, 0.1, 2.0];
+            for &h in hs.iter() {
+                let scalar = CubicSplineKernel::new(h);
+                let avx = CubicSplineKernelAvxF32::new(h);
+
+                // Sample radii from 0 to 2h (beyond support should be 0)
+                let n: usize = 1024;
+                let mut r0: f32 = 0.0;
+                let dr: f32 = (2.0 * h) / (n as f32);
+
+                for _chunk in 0..(n / 8) {
+                    // Prepare 8 lanes of radii
+                    let rs = [
+                        r0,
+                        r0 + dr,
+                        r0 + 2.0 * dr,
+                        r0 + 3.0 * dr,
+                        r0 + 4.0 * dr,
+                        r0 + 5.0 * dr,
+                        r0 + 6.0 * dr,
+                        r0 + 7.0 * dr,
+                    ];
+
+                    // Evaluate AVX and store back to array
+                    let r_vec = unsafe { _mm256_loadu_ps(rs.as_ptr()) };
+                    let w_vec = unsafe { avx.evaluate(r_vec) };
+                    let mut w_avx = [0.0f32; 8];
+                    unsafe { _mm256_storeu_ps(w_avx.as_mut_ptr(), w_vec) };
+
+                    // Compare against scalar lane-wise
+                    for lane in 0..8 {
+                        let r_lane = rs[lane];
+                        let w_scalar = scalar.evaluate(r_lane);
+                        let diff = (w_avx[lane] - w_scalar).abs();
+
+                        // Absolute tolerance with mild relative component to be robust across scales
+                        let tol = 1e-6_f32.max(1e-5_f32 * w_scalar.abs());
+                        assert!(
+                            diff <= tol,
+                            "AVX kernel mismatch (h={}, r={}, lane={}): avx={}, scalar={}, diff={}, tol={}",
+                            h,
+                            r_lane,
+                            lane,
+                            w_avx[lane],
+                            w_scalar,
+                            diff,
+                            tol
+                        );
+                    }
+
+                    r0 += 8.0 * dr;
+                }
+
+                // Also check a couple of out-of-support points explicitly
+                for &r in &[h * 1.01, h * 1.5, h * 2.0, h * 2.5] {
+                    let w_scalar = scalar.evaluate(r);
+                    let w_avx = {
+                        let v = unsafe { _mm256_set1_ps(r) };
+                        let w = unsafe { avx.evaluate(v) };
+                        let mut tmp = [0.0f32; 8];
+                        unsafe { _mm256_storeu_ps(tmp.as_mut_ptr(), w) };
+                        tmp[0]
+                    };
+                    let diff = (w_avx - w_scalar).abs();
+                    let tol = 1e-6_f32.max(1e-5_f32 * w_scalar.abs());
+                    assert!(
+                        diff <= tol,
+                        "AVX kernel mismatch outside support (h={}, r={}): avx={}, scalar={}, diff={}, tol={}",
+                        h,
+                        r,
+                        w_avx,
+                        w_scalar,
+                        diff,
+                        tol
+                    );
+                }
+            }
+        }
+    }
+
+
+    #[test]
+    fn discrete_cubic_kernel() {
+        let n = 10000;
+        let h = 0.025;
+
+        let discrete_kernel = DiscreteSquaredDistanceCubicKernel::new::<f64>(n, h);
+        let kernel = CubicSplineKernel::new(h);
+
+        // Test the pre-computed values using a linear stepping
+        let dr = h / (n as f64);
+        for i in 0..n {
+            let r = (i as f64) * dr;
+            let rr = r * r;
+
+            let discrete = discrete_kernel.evaluate(rr);
+            let continuous = kernel.evaluate(r);
+
+            let diff = (discrete - continuous).abs();
+            let rel_diff = diff / continuous;
+            if rel_diff > 5e-2 && diff > 1e-1 {
+                eprintln!(
+                    "at r={}, r/h={}, discrete: {}, continuous: {}, diff: {}, rel_diff: {}",
+                    r,
+                    r / h,
+                    discrete,
+                    continuous,
+                    diff,
+                    rel_diff
+                );
+                assert!(false);
+            }
+        }
+    }
+
+    #[test]
+    fn poly6_kernel_r_compact_support() {
+        test_kernel_r_compact_support!(Poly6Kernel);
+    }
+
+    #[test]
+    fn poly6_kernel_r_integral() {
+        test_kernel_r_integral!(Poly6Kernel);
+    }
+
+    #[test]
+    fn spiky_kernel_r_compact_support() {
+        test_kernel_r_compact_support!(SpikyKernel);
+    }
+
+    #[test]
+    fn spiky_kernel_r_integral() {
+        test_kernel_r_integral!(SpikyKernel);
+    }
+
+    #[test]
+    fn wendland_quintic_c2_kernel_r_compact_support() {
+        test_kernel_r_compact_support!(WendlandQuinticC2Kernel);
+    }
+
+    #[test]
+    fn wendland_quintic_c2_kernel_r_integral() {
+        test_kernel_r_integral!(WendlandQuinticC2Kernel);
     }
 }

--- a/splashsurf_lib/src/lib.rs
+++ b/splashsurf_lib/src/lib.rs
@@ -42,6 +42,7 @@ pub use crate::traits::{Index, Real, RealConvert, ThreadSafe};
 pub use crate::uniform_grid::UniformGrid;
 
 use crate::density_map::DensityMapError;
+use crate::kernel::KernelType;
 use crate::marching_cubes::MarchingCubesError;
 use crate::mesh::TriMesh3d;
 use crate::uniform_grid::GridConstructionError;
@@ -186,6 +187,7 @@ pub struct Parameters<R: Scalar> {
     /// Depending on the settings of the reconstruction, neighborhood lists are only computed locally
     /// in subdomains. Enabling this flag joins this data over all particles which can add a small overhead.
     pub global_neighborhood_list: bool,
+    pub kernel_type: KernelType,
 }
 
 impl<R: Real> Parameters<R> {
@@ -206,6 +208,7 @@ impl<R: Real> Parameters<R> {
             enable_simd: true,
             spatial_decomposition: Default::default(),
             global_neighborhood_list: false,
+            kernel_type: KernelType::CubicSpline,
         }
     }
 
@@ -238,6 +241,7 @@ impl<R: Real> Parameters<R> {
             enable_simd: self.enable_simd,
             spatial_decomposition: self.spatial_decomposition.clone(),
             global_neighborhood_list: self.global_neighborhood_list,
+            kernel_type: self.kernel_type.clone(),
         })
     }
 }

--- a/splashsurf_lib/src/sph_interpolation.rs
+++ b/splashsurf_lib/src/sph_interpolation.rs
@@ -1,9 +1,9 @@
 //! Functions for interpolating quantities (e.g. normals, scalar fields) by evaluating SPH sums
 
 use crate::Real;
-use crate::kernel::SymmetricKernel3d;
+use crate::kernel::{CubicSplineKernel, KernelType, Poly6Kernel, SpikyKernel, SymmetricKernel3d, WendlandQuinticC2Kernel};
 use crate::profile;
-use crate::{ThreadSafe, kernel};
+use crate::ThreadSafe;
 use nalgebra::{SVector, Unit, Vector3};
 use rayon::prelude::*;
 use rstar::RTree;
@@ -14,6 +14,7 @@ use std::ops::AddAssign;
 pub struct SphInterpolator<R: Real> {
     compact_support_radius: R,
     tree: RTree<Particle<R>>,
+    kernel_type: KernelType,
 }
 
 /// Particle type that is stored in the R-tree for fast SPH neighbor queries
@@ -62,6 +63,7 @@ impl<R: Real> SphInterpolator<R> {
         particle_densities: &[R],
         particle_rest_mass: R,
         compact_support_radius: R,
+        kernel_type: KernelType
     ) -> Self {
         assert_eq!(particle_positions.len(), particle_densities.len());
 
@@ -70,6 +72,7 @@ impl<R: Real> SphInterpolator<R> {
         Self {
             compact_support_radius,
             tree,
+            kernel_type,
         }
     }
 
@@ -86,40 +89,70 @@ impl<R: Real> SphInterpolator<R> {
     ) {
         profile!("interpolate_normals_inplace");
 
-        let squared_support = self.compact_support_radius * self.compact_support_radius;
-        let kernel = kernel::CubicSplineKernel::new(self.compact_support_radius);
+        fn interpolate_normals_helper<R: Real, K: SymmetricKernel3d<R> + Sync>(
+            sph: &SphInterpolator<R>,
+            interpolation_points: &[Vector3<R>],
+            normals: &mut Vec<Unit<Vector3<R>>>,
+        ) {
+            let squared_support = sph.compact_support_radius * sph.compact_support_radius;
 
-        interpolation_points
-            .par_iter()
-            .map(|x_i| {
-                // Compute the gradient of the particle density field which points in the same direction as surface normals
-                let mut density_grad = Vector3::zeros();
+            let kernel = K::new(sph.compact_support_radius);
 
-                // SPH: Iterate over all other particles within the squared support radius
-                let query_point = bytemuck::cast::<_, [R; 3]>(*x_i);
-                for p_j in self
-                    .tree
-                    .locate_within_distance(query_point, squared_support)
-                {
-                    // Volume of the neighbor particle
-                    let vol_j = p_j.data.volume;
-                    // Position of the neighbor particle
-                    let x_j = bytemuck::cast_ref::<_, Vector3<R>>(p_j.geom());
+            interpolation_points
+                .par_iter()
+                .map(|x_i| {
+                    // Compute the gradient of the particle density field which points in the same direction as surface normals
+                    let mut density_grad = Vector3::zeros();
 
-                    // Relative position `dx` and distance `r` of the neighbor particle
-                    let dx = x_j - x_i;
-                    let r = dx.norm();
+                    // SPH: Iterate over all other particles within the squared support radius
+                    let query_point = bytemuck::cast::<_, [R; 3]>(*x_i);
+                    for p_j in sph
+                        .tree
+                        .locate_within_distance(query_point, squared_support)
+                    {
+                        // Volume of the neighbor particle
+                        let vol_j = p_j.data.volume;
+                        // Position of the neighbor particle
+                        let x_j = bytemuck::cast_ref::<_, Vector3<R>>(p_j.geom());
 
-                    // Compute the contribution of the neighbor to the gradient of the density field
-                    // TODO: Replace this by a discrete gradient norm evaluation
-                    let kernel_grad = dx.unscale(r) * kernel.evaluate_gradient_norm(r);
-                    density_grad += kernel_grad * vol_j;
-                }
+                        // Relative position `dx` and distance `r` of the neighbor particle
+                        let dx = x_j - x_i;
+                        let r = dx.norm();
 
-                // Normalize the gradient to get the surface normal
-                Unit::new_normalize(density_grad)
-            })
-            .collect_into_vec(normals);
+                        // Compute the contribution of the neighbor to the gradient of the density field
+                        // TODO: Replace this by a discrete gradient norm evaluation
+                        let kernel_grad = dx.unscale(r) * kernel.evaluate_gradient_norm(r);
+                        density_grad += kernel_grad * vol_j;
+                    }
+
+                    // Normalize the gradient to get the surface normal
+                    Unit::new_normalize(density_grad)
+                })
+                .collect_into_vec(normals);
+        }
+
+        match self.kernel_type {
+            KernelType::CubicSpline => interpolate_normals_helper::<R, CubicSplineKernel<R>>(
+                self,
+                interpolation_points,
+                normals,
+            ),
+            KernelType::Poly6 => interpolate_normals_helper::<R, Poly6Kernel<R>>(
+                self,
+                interpolation_points,
+                normals,
+            ),
+            KernelType::Spiky => interpolate_normals_helper::<R, SpikyKernel<R>>(
+                self,
+                interpolation_points,
+                normals,
+            ),
+            KernelType::WendlandQuinticC2 => interpolate_normals_helper::<R, WendlandQuinticC2Kernel<R>>(
+                self,
+                interpolation_points,
+                normals,
+            ),
+        }
     }
 
     /// Interpolates surface normals (i.e. normalized SPH gradient of the indicator function) of the fluid to the given points using SPH interpolation
@@ -212,49 +245,88 @@ impl<R: Real> SphInterpolator<R> {
         profile!("interpolate_quantity_inplace");
         assert_eq!(particle_quantity.len(), self.tree.size());
 
-        let squared_support = self.compact_support_radius * self.compact_support_radius;
-        let kernel = kernel::CubicSplineKernel::new(self.compact_support_radius);
+        fn interpolate_quantity_helper<R: Real, T: InterpolationQuantity<R>, K: SymmetricKernel3d<R> + Sync>(
+            sph: &SphInterpolator<R>,
+            particle_quantity: &[T],
+            interpolation_points: &[Vector3<R>],
+            interpolated_values: &mut Vec<T>,
+            first_order_correction: bool,
+        ) {
+            let squared_support = sph.compact_support_radius * sph.compact_support_radius;
+            let kernel = K::new(sph.compact_support_radius);
 
-        let enable_correction = if first_order_correction {
-            R::one()
-        } else {
-            R::zero()
-        };
+            let enable_correction = if first_order_correction {
+                R::one()
+            } else {
+                R::zero()
+            };
 
-        interpolation_points
-            .par_iter()
-            .map(|x_i| {
-                let mut interpolated_value = T::zero();
-                let mut correction = R::zero();
+            interpolation_points
+                .par_iter()
+                .map(|x_i| {
+                    let mut interpolated_value = T::zero();
+                    let mut correction = R::zero();
 
-                // SPH: Iterate over all other particles within the squared support radius
-                let query_point = bytemuck::cast::<_, [R; 3]>(*x_i);
-                for p_j in self
-                    .tree
-                    .locate_within_distance(query_point, squared_support)
-                {
-                    // Volume of the neighbor particle
-                    let vol_j = p_j.data.volume;
-                    // Position of the neighbor particle
-                    let x_j = bytemuck::cast_ref::<_, Vector3<R>>(p_j.geom());
+                    // SPH: Iterate over all other particles within the squared support radius
+                    let query_point = bytemuck::cast::<_, [R; 3]>(*x_i);
+                    for p_j in sph
+                        .tree
+                        .locate_within_distance(query_point, squared_support)
+                    {
+                        // Volume of the neighbor particle
+                        let vol_j = p_j.data.volume;
+                        // Position of the neighbor particle
+                        let x_j = bytemuck::cast_ref::<_, Vector3<R>>(p_j.geom());
 
-                    // Relative position `dx` and distance `r` of the neighbor particle
-                    let dx = x_j - x_i;
-                    let r = dx.norm();
+                        // Relative position `dx` and distance `r` of the neighbor particle
+                        let dx = x_j - x_i;
+                        let r = dx.norm();
 
-                    // Unchecked access is fine as we asserted before that the slice has the correct length
-                    let A_j = unsafe { particle_quantity.get_unchecked(p_j.data.index).clone() };
-                    let W_ij = kernel.evaluate(r);
+                        // Unchecked access is fine as we asserted before that the slice has the correct length
+                        let A_j = unsafe { particle_quantity.get_unchecked(p_j.data.index).clone() };
+                        let W_ij = kernel.evaluate(r);
 
-                    interpolated_value += A_j.scale(vol_j * W_ij);
-                    correction += vol_j * W_ij;
-                }
+                        interpolated_value += A_j.scale(vol_j * W_ij);
+                        correction += vol_j * W_ij;
+                    }
 
-                let correction_factor =
-                    enable_correction * correction.recip() + (R::one() - enable_correction);
-                interpolated_value.scale(correction_factor)
-            })
-            .collect_into_vec(interpolated_values);
+                    let correction_factor =
+                        enable_correction * correction.recip() + (R::one() - enable_correction);
+                    interpolated_value.scale(correction_factor)
+                })
+                .collect_into_vec(interpolated_values);
+        }
+
+        match self.kernel_type {
+            KernelType::CubicSpline => interpolate_quantity_helper::<R, T, CubicSplineKernel<R>>(
+                self,
+                particle_quantity,
+                interpolation_points,
+                interpolated_values,
+                first_order_correction,
+            ),
+            KernelType::Poly6 => interpolate_quantity_helper::<R, T, Poly6Kernel<R>>(
+                self,
+                particle_quantity,
+                interpolation_points,
+                interpolated_values,
+                first_order_correction,
+            ),
+            KernelType::Spiky => interpolate_quantity_helper::<R, T, SpikyKernel<R>>(
+                self,
+                particle_quantity,
+                interpolation_points,
+                interpolated_values,
+                first_order_correction,
+            ),
+            KernelType::WendlandQuinticC2 => interpolate_quantity_helper::<R, T, WendlandQuinticC2Kernel<R>>(
+                self,
+                particle_quantity,
+                interpolation_points,
+                interpolated_values,
+                first_order_correction,
+            ),
+        }
     }
 }
 

--- a/splashsurf_lib/tests/integration_tests/test_full.rs
+++ b/splashsurf_lib/tests/integration_tests/test_full.rs
@@ -7,7 +7,7 @@ use splashsurf_lib::{
     reconstruct_surface,
 };
 use std::path::Path;
-
+use splashsurf_lib::kernel::KernelType;
 // TODO: Compare with a solution file
 // TODO: Test with a fixed grid?
 
@@ -38,6 +38,7 @@ fn params_with_aabb<R: Real>(
         enable_simd: false,
         spatial_decomposition: SpatialDecomposition::None,
         global_neighborhood_list: false,
+        kernel_type: KernelType::CubicSpline,
     };
 
     match strategy {

--- a/splashsurf_lib/tests/integration_tests/test_full.rs
+++ b/splashsurf_lib/tests/integration_tests/test_full.rs
@@ -1,13 +1,13 @@
 use nalgebra::Vector3;
 use splashsurf_lib::io::particles_from_file;
 use splashsurf_lib::io::vtk_format::write_vtk;
+use splashsurf_lib::kernel::KernelType;
 use splashsurf_lib::marching_cubes::check_mesh_consistency;
 use splashsurf_lib::{
     Aabb3d, GridDecompositionParameters, Parameters, Real, SpatialDecomposition,
     reconstruct_surface,
 };
 use std::path::Path;
-use splashsurf_lib::kernel::KernelType;
 // TODO: Compare with a solution file
 // TODO: Test with a fixed grid?
 

--- a/splashsurf_lib/tests/integration_tests/test_simple.rs
+++ b/splashsurf_lib/tests/integration_tests/test_simple.rs
@@ -4,6 +4,7 @@ use splashsurf_lib::{
     Aabb3d, GridDecompositionParameters, Parameters, Real, SpatialDecomposition,
     reconstruct_surface,
 };
+use splashsurf_lib::kernel::KernelType;
 
 enum Strategy {
     Global,
@@ -32,6 +33,7 @@ fn params_with_aabb<R: Real>(
         enable_simd: false,
         spatial_decomposition: SpatialDecomposition::None,
         global_neighborhood_list: false,
+        kernel_type: KernelType::CubicSpline,
     };
 
     match strategy {

--- a/splashsurf_lib/tests/integration_tests/test_simple.rs
+++ b/splashsurf_lib/tests/integration_tests/test_simple.rs
@@ -1,10 +1,10 @@
 use nalgebra::Vector3;
+use splashsurf_lib::kernel::KernelType;
 use splashsurf_lib::marching_cubes::check_mesh_consistency;
 use splashsurf_lib::{
     Aabb3d, GridDecompositionParameters, Parameters, Real, SpatialDecomposition,
     reconstruct_surface,
 };
-use splashsurf_lib::kernel::KernelType;
 
 enum Strategy {
     Global,

--- a/splashsurf_lib/tests/integration_tests/test_subdomains.rs
+++ b/splashsurf_lib/tests/integration_tests/test_subdomains.rs
@@ -5,6 +5,7 @@ use splashsurf_lib::GridDecompositionParameters;
 use splashsurf_lib::io::vtk_format::write_vtk;
 use splashsurf_lib::marching_cubes::check_mesh_consistency;
 use std::path::Path;
+use splashsurf_lib::kernel::KernelType;
 
 macro_rules! generate_single_particle_test {
     ($test_name:ident, $output_file:literal, cube_size = $cube_size_rel:literal, tris = $range_tri:expr, verts = $range_vert:expr, subdomains = $range_subdomains:expr) => {
@@ -31,6 +32,7 @@ macro_rules! generate_single_particle_test {
                 ),
                 rest_density: 1000.0,
                 global_neighborhood_list: false,
+                kernel_type: KernelType::CubicSpline,
             };
 
             let reconstruction =

--- a/splashsurf_lib/tests/integration_tests/test_subdomains.rs
+++ b/splashsurf_lib/tests/integration_tests/test_subdomains.rs
@@ -3,9 +3,9 @@ use nalgebra::Vector3;
 use splashsurf_lib::GridDecompositionParameters;
 #[cfg(feature = "io")]
 use splashsurf_lib::io::vtk_format::write_vtk;
+use splashsurf_lib::kernel::KernelType;
 use splashsurf_lib::marching_cubes::check_mesh_consistency;
 use std::path::Path;
-use splashsurf_lib::kernel::KernelType;
 
 macro_rules! generate_single_particle_test {
     ($test_name:ident, $output_file:literal, cube_size = $cube_size_rel:literal, tris = $range_tri:expr, verts = $range_vert:expr, subdomains = $range_subdomains:expr) => {


### PR DESCRIPTION
This PR adds the poly6, spiky and Wendland quintic C2 kernels alongside the standard cubic spline kernel in splashsurf_lib and enables the user to switch between them in the CLI and python bindings.